### PR TITLE
Check results

### DIFF
--- a/check.go
+++ b/check.go
@@ -7,11 +7,12 @@ import (
 	"sort"
 )
 
+// Result of a Check
 type Result struct {
-	Failures []Failure
-	// XXX perhaps this is a list of the failed files and keywords?
+	Failures []Failure // list of any failures in the Check
 }
 
+// Failure of a particular keyword for a path
 type Failure struct {
 	Path     string
 	Keyword  string
@@ -19,10 +20,12 @@ type Failure struct {
 	Got      string
 }
 
+// String returns a "pretty" formatting for a Failure
 func (f Failure) String() string {
 	return fmt.Sprintf("%q: keyword %q: expected %s; got %s", f.Path, f.Keyword, f.Expected, f.Got)
 }
 
+// Check a root directory path for a DirectoryHierarchy
 func Check(root string, dh *DirectoryHierarchy) (*Result, error) {
 	creator := dhCreator{DH: dh}
 	curDir, err := os.Getwd()

--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -98,8 +98,10 @@ func main() {
 			isErr = true
 			return
 		}
-		if res != nil {
-			fmt.Printf("%#v\n", res)
+		if res != nil && len(res.Failures) > 0 {
+			for _, failure := range res.Failures {
+				fmt.Println(failure)
+			}
 		}
 	}
 }

--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -99,6 +99,7 @@ func main() {
 			return
 		}
 		if res != nil && len(res.Failures) > 0 {
+			defer os.Exit(1)
 			for _, failure := range res.Failures {
 				fmt.Println(failure)
 			}

--- a/hierarchy.go
+++ b/hierarchy.go
@@ -46,6 +46,7 @@ type Entry struct {
 	Type          EntryType
 }
 
+// Path provides the full path of the file, despite RelativeType or FullType
 func (e Entry) Path() string {
 	if e.Parent == nil || e.Type == FullType {
 		return e.Name

--- a/parse.go
+++ b/parse.go
@@ -53,6 +53,9 @@ func ParseSpec(r io.Reader) (*DirectoryHierarchy, error) {
 		case len(strings.Fields(str)) > 0 && strings.Fields(str)[0] == "..":
 			e.Type = DotDotType
 			e.Raw = str
+			if creator.curDir != nil {
+				creator.curDir = creator.curDir.Parent
+			}
 			// nothing else to do here
 		case len(strings.Fields(str)) > 0:
 			// collapse any escaped newlines
@@ -74,6 +77,7 @@ func ParseSpec(r io.Reader) (*DirectoryHierarchy, error) {
 			}
 			e.Name = f[0]
 			e.Keywords = f[1:]
+			e.Parent = creator.curDir
 			for i := range e.Keywords {
 				kv := KeyVal(e.Keywords[i])
 				if kv.Keyword() == "type" {


### PR DESCRIPTION
This makes the result set more useful. Also, this fixes a bug for deriving paths of an entry when parsing an mtree file specification.