### PR TITLE
check: keyword filtering the checks

### DIFF
--- a/check.go
+++ b/check.go
@@ -25,8 +25,10 @@ func (f Failure) String() string {
 	return fmt.Sprintf("%q: keyword %q: expected %s; got %s", f.Path, f.Keyword, f.Expected, f.Got)
 }
 
-// Check a root directory path for a DirectoryHierarchy
-func Check(root string, dh *DirectoryHierarchy) (*Result, error) {
+// Check a root directory path against the DirectoryHierarchy, regarding only
+// the available keywords from the list and each entry in the hierarchy.
+// If keywords is nil, the check all present in the DirectoryHierarchy
+func Check(root string, dh *DirectoryHierarchy, keywords []string) (*Result, error) {
 	creator := dhCreator{DH: dh}
 	curDir, err := os.Getwd()
 	if err == nil {
@@ -61,6 +63,9 @@ func Check(root string, dh *DirectoryHierarchy) (*Result, error) {
 			}
 
 			for _, kv := range kvs {
+				if keywords != nil && !inSlice(kv.Keyword(), keywords) {
+					continue
+				}
 				keywordFunc, ok := KeywordFuncs[kv.Keyword()]
 				if !ok {
 					return nil, fmt.Errorf("Unknown keyword %q for file %q", kv.Keyword(), e.Path())

--- a/check_test.go
+++ b/check_test.go
@@ -80,3 +80,18 @@ func TestCheckKeywords(t *testing.T) {
 		t.Errorf("%#v", res)
 	}
 }
+
+func ExampleCheck() {
+	dh, err := Walk(".", nil, append(DefaultKeywords, "sha1"))
+	if err != nil {
+		// handle error ...
+	}
+
+	res, err := Check(".", dh, nil)
+	if err != nil {
+		// handle error ...
+	}
+	if len(res.Failures) > 0 {
+		// handle failed validity ...
+	}
+}

--- a/check_test.go
+++ b/check_test.go
@@ -1,14 +1,22 @@
 package mtree
 
-import "testing"
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
 
+// simple walk of current directory, and imediately check it.
+// may not be parallelizable.
 func TestCheck(t *testing.T) {
 	dh, err := Walk(".", nil, append(DefaultKeywords, "sha1"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	res, err := Check(".", dh)
+	res, err := Check(".", dh, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -18,4 +26,57 @@ func TestCheck(t *testing.T) {
 	}
 }
 
-// TODO make a directory, walk it, check it, modify it and ensure it fails
+// make a directory, walk it, check it, modify the timestamp and ensure it fails.
+// only check again for size and sha1, and ignore time, and ensure it passes
+func TestCheckKeywords(t *testing.T) {
+	content := []byte("I know half of you half as well as I ought to")
+	dir, err := ioutil.TempDir("", "test-check-keywords")
+	if err != nil {
+		t.Fatal(err)
+	}
+	//defer os.RemoveAll(dir) // clean up
+
+	tmpfn := filepath.Join(dir, "tmpfile")
+	if err := ioutil.WriteFile(tmpfn, content, 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	// Walk this tempdir
+	dh, err := Walk(dir, nil, append(DefaultKeywords, "sha1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check for sanity. This ought to pass.
+	res, err := Check(dir, dh, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Failures) > 0 {
+		t.Errorf("%#v", res)
+	}
+
+	// Touch a file, so the mtime changes.
+	now := time.Now()
+	if err := os.Chtimes(tmpfn, now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check again. This ought to fail.
+	res, err = Check(dir, dh, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Failures) == 0 {
+		t.Errorf("expected to fail on changed mtimes, but did not")
+	}
+
+	// Check again, but only sha1 and mode. This ought to pass.
+	res, err = Check(dir, dh, []string{"sha1", "mode"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Failures) > 0 {
+		t.Errorf("%#v", res)
+	}
+}

--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -92,7 +92,7 @@ func main() {
 		dh.WriteTo(os.Stdout)
 	} else {
 		// else this is a validation
-		res, err := mtree.Check(rootPath, dh)
+		res, err := mtree.Check(rootPath, dh, currentKeywords)
 		if err != nil {
 			log.Println(err)
 			isErr = true


### PR DESCRIPTION
Allow for `Check()` to be narrowed to a set of keywords.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>