### PR TITLE
Recognize path when validating

### DIFF
--- a/check.go
+++ b/check.go
@@ -50,7 +50,7 @@ func Check(root string, dh *DirectoryHierarchy, keywords []string) (*Result, err
 				creator.curSet = nil
 			}
 		case RelativeType, FullType:
-			info, err := os.Lstat(filepath.Join(root, e.Path()))
+			info, err := os.Lstat(e.Path())
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fixes #11 . Check() changes the current directory it is in to the `root` argument a user specifies. Thus, once we are in that directory, we should be stepping through files with relative path names, not `root`/`basename`. 