### PR TITLE
check: recognize correct path

### DIFF
--- a/check.go
+++ b/check.go
@@ -50,7 +50,7 @@ func Check(root string, dh *DirectoryHierarchy, keywords []string) (*Result, err
 				creator.curSet = nil
 			}
 		case RelativeType, FullType:
-			info, err := os.Lstat(filepath.Join(root, e.Path()))
+			info, err := os.Lstat(e.Path())
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fixes #11. Check() changes its working directory to `root`, which is specified as an argument. Thus, it shouldn't call `os.Lstat` on a file using its absolute path; instead it should open the file
with the relative path to the root.