### PR TITLE
check: creator.curSet pointer aliasing

### DIFF
--- a/check.go
+++ b/check.go
@@ -41,11 +41,11 @@ func Check(root string, dh *DirectoryHierarchy, keywords []string) (*Result, err
 	sort.Sort(byPos(creator.DH.Entries))
 
 	var result Result
-	for _, e := range creator.DH.Entries {
+	for i, e := range creator.DH.Entries {
 		switch e.Type {
 		case SpecialType:
 			if e.Name == "/set" {
-				creator.curSet = &e
+				creator.curSet = &creator.DH.Entries[i]
 			} else if e.Name == "/unset" {
 				creator.curSet = nil
 			}

--- a/check_test.go
+++ b/check_test.go
@@ -108,7 +108,7 @@ func TestTimeComparison(t *testing.T) {
 	// This is the format of time from FreeBSD
 	spec := `
 /set type=file time=5.000000000
-.               type=dir 
+.               type=dir
     file       time=5.000000000
 ..
 `
@@ -120,6 +120,9 @@ func TestTimeComparison(t *testing.T) {
 	// This is what mode we're checking for. Round integer of epoch seconds
 	epoch := time.Unix(5, 0)
 	if err := os.Chtimes(fh.Name(), epoch, epoch); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(dir, epoch, epoch); err != nil {
 		t.Fatal(err)
 	}
 	if err := fh.Close(); err != nil {


### PR DESCRIPTION
Fixes a pointer aliasing bug. creator.curSet was being set to the address of the variable `e` iterating over the range of Entries, and this caused the underlying value of the Entry it points to to change on each iteration.