### PR TITLE
main: 'type' keyword should always be evaluated

### DIFF
--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -47,6 +47,9 @@ func main() {
 	// -k <keywords>
 	if *flUseKeywords != "" {
 		currentKeywords = splitKeywordsArg(*flUseKeywords)
+		if !inSlice("type", currentKeywords) {
+			currentKeywords = append([]string{"type"}, currentKeywords...)
+		}
 	} else {
 		currentKeywords = mtree.DefaultKeywords[:]
 	}


### PR DESCRIPTION
Resolves #21 . 'type' keyword is a default that should always be evaluated, aligning with upstream mtree.