### PR TITLE
main: change `-l` to `-list-keywords`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,32 @@ gomtree -p . -f /tmp/mtree.txt
 ### See the supported keywords
 
 ```bash
-gomtree -l
+gomtree -list-keywords
+Available keywords:
+  rmd160
+  ripemd160digest
+  type  (default)
+  link  (default)
+  cksum
+  md5
+  md5digest
+  sha256digest
+  sha512
+  time  (default)
+  gid  (default)
+  mode  (default)
+  sha1
+  sha1digest
+  size  (default)
+  uid  (default)
+  sha256
+  sha384
+  sha512digest
+  nlink  (default)
+  uname
+  rmd160digest
+  sha384digest
+  xattr
 ```
 
 

--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -16,7 +16,7 @@ var (
 	flPath         = flag.String("p", "", "root path that the hierarchy spec is relative to")
 	flAddKeywords  = flag.String("K", "", "Add the specified (delimited by comma or space) keywords to the current set of keywords")
 	flUseKeywords  = flag.String("k", "", "Use the specified (delimited by comma or space) keywords as the current set of keywords")
-	flListKeywords = flag.Bool("l", false, "List the keywords available")
+	flListKeywords = flag.Bool("list-keywords", false, "List the keywords available")
 )
 
 func main() {


### PR DESCRIPTION
The FreeBSD flag `-l` is already used and has differing behavior, so
switch to not conflict

Reported-by: Aleksa Sarai <asarai@suse.de>
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>