### PR TITLE
cmd: add alternate formats

### DIFF
--- a/check.go
+++ b/check.go
@@ -9,15 +9,16 @@ import (
 
 // Result of a Check
 type Result struct {
-	Failures []Failure // list of any failures in the Check
+	// list of any failures in the Check
+	Failures []Failure `json:"failures"`
 }
 
 // Failure of a particular keyword for a path
 type Failure struct {
-	Path     string
-	Keyword  string
-	Expected string
-	Got      string
+	Path     string `json:"path"`
+	Keyword  string `json:"keyword"`
+	Expected string `json:"expected"`
+	Got      string `json:"got"`
 }
 
 // String returns a "pretty" formatting for a Failure

--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -27,6 +28,14 @@ var formats = map[string]func(*mtree.Result) string{
 		var buffer bytes.Buffer
 		for _, fail := range r.Failures {
 			fmt.Fprintln(&buffer, fail)
+		}
+		return buffer.String()
+	},
+
+	"json": func(r *mtree.Result) string {
+		var buffer bytes.Buffer
+		if err := json.NewEncoder(&buffer).Encode(r); err != nil {
+			panic(err)
 		}
 		return buffer.String()
 	},

--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -32,10 +32,20 @@ var formats = map[string]func(*mtree.Result) string{
 		return buffer.String()
 	},
 
+	// Outputs the full result struct in JSON.
 	"json": func(r *mtree.Result) string {
 		var buffer bytes.Buffer
 		if err := json.NewEncoder(&buffer).Encode(r); err != nil {
 			panic(err)
+		}
+		return buffer.String()
+	},
+
+	// Outputs only the paths which failed to validate.
+	"path": func(r *mtree.Result) string {
+		var buffer bytes.Buffer
+		for _, fail := range r.Failures {
+			fmt.Fprintln(&buffer, fail.Path)
 		}
 		return buffer.String()
 	},


### PR DESCRIPTION
This adds the following `--output` formats:

* `bsd` (the default and the original version).
* `json` which outputs a JSON encoded version of the struct for easier parsing.
* `path` which just outputs the full path which failed for easier parsing by shell scripts and the like.

Signed-off-by: Aleksa Sarai <asarai@suse.de>