### PR TITLE
vis: refactored code to reflect using vis() to represent file names

### DIFF
--- a/check.go
+++ b/check.go
@@ -50,7 +50,11 @@ func Check(root string, dh *DirectoryHierarchy, keywords []string) (*Result, err
 				creator.curSet = nil
 			}
 		case RelativeType, FullType:
-			info, err := os.Lstat(e.Path())
+			pathname, err := e.Path()
+			if err != nil {
+				return nil, err
+			}
+			info, err := os.Lstat(pathname)
 			if err != nil {
 				return nil, err
 			}
@@ -65,17 +69,17 @@ func Check(root string, dh *DirectoryHierarchy, keywords []string) (*Result, err
 			for _, kv := range kvs {
 				keywordFunc, ok := KeywordFuncs[kv.Keyword()]
 				if !ok {
-					return nil, fmt.Errorf("Unknown keyword %q for file %q", kv.Keyword(), e.Path())
+					return nil, fmt.Errorf("Unknown keyword %q for file %q", kv.Keyword(), pathname)
 				}
 				if keywords != nil && !inSlice(kv.Keyword(), keywords) {
 					continue
 				}
-				curKeyVal, err := keywordFunc(filepath.Join(root, e.Path()), info)
+				curKeyVal, err := keywordFunc(filepath.Join(root, pathname), info)
 				if err != nil {
 					return nil, err
 				}
 				if string(kv) != curKeyVal {
-					failure := Failure{Path: e.Path(), Keyword: kv.Keyword(), Expected: kv.Value(), Got: KeyVal(curKeyVal).Value()}
+					failure := Failure{Path: pathname, Keyword: kv.Keyword(), Expected: kv.Value(), Got: KeyVal(curKeyVal).Value()}
 					result.Failures = append(result.Failures, failure)
 				}
 			}

--- a/check_test.go
+++ b/check_test.go
@@ -208,3 +208,38 @@ func TestIgnoreComments(t *testing.T) {
 		t.Fatal(res.Failures)
 	}
 }
+
+func TestCheckNeedsEncoding(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-needs-encoding")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	fh, err := os.Create(filepath.Join(dir, "file[ "))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fh.Close(); err != nil {
+		t.Error(err)
+	}
+	fh, err = os.Create(filepath.Join(dir, "    , should work"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fh.Close(); err != nil {
+		t.Error(err)
+	}
+
+	dh, err := Walk(dir, nil, DefaultKeywords)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := Check(dir, dh, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Failures) > 0 {
+		t.Fatal(res.Failures)
+	}
+}

--- a/unvis.go
+++ b/unvis.go
@@ -1,15 +1,23 @@
 package mtree
 
 // #include "vis.h"
+// #include <stdlib.h>
 import "C"
-import "fmt"
+import (
+	"fmt"
+	"unsafe"
+)
 
-func Unvis(str string) (string, error) {
-	dst := new(C.char)
-	ret := C.strunvis(dst, C.CString(str))
-	if ret == 0 {
-		return "", fmt.Errorf("failed to encode string")
+// Unvis is a wrapper for the C implementation of unvis, which decodes a string
+// that potentially has characters that are encoded with Vis
+func Unvis(src string) (string, error) {
+	cDst, cSrc := C.CString(string(make([]byte, len(src)+1))), C.CString(src)
+	defer C.free(unsafe.Pointer(cDst))
+	defer C.free(unsafe.Pointer(cSrc))
+	ret := C.strunvis(cDst, cSrc)
+	if ret == -1 {
+		return "", fmt.Errorf("failed to decode: %q", src)
 	}
 
-	return C.GoString(dst), nil
+	return C.GoString(cDst), nil
 }

--- a/vis_test.go
+++ b/vis_test.go
@@ -9,13 +9,17 @@ func TestVis(t *testing.T) {
 		{"[", "\\133"},
 		{" ", "\\040"},
 		{"	", "\\011"},
+		{"dir with space", "dir\\040with\\040space"},
+		{"consec   spaces", "consec\\040\\040\\040spaces"},
+		{"trailingsymbol[", "trailingsymbol\\133"},
+		{" [ leadingsymbols", "\\040\\133\\040leadingsymbols"},
+		{"no_need_for_encoding", "no_need_for_encoding"},
 	}
 
 	for i := range testset {
 		got, err := Vis(testset[i].Src)
 		if err != nil {
 			t.Errorf("working with %q: %s", testset[i].Src, err)
-			continue
 		}
 		if got != testset[i].Dest {
 			t.Errorf("expected %#v; got %#v", testset[i].Dest, got)
@@ -31,5 +35,15 @@ func TestVis(t *testing.T) {
 			t.Errorf("expected %#v; got %#v", testset[i].Src, got)
 			continue
 		}
+	}
+}
+
+// The resulting string of Vis output could potentially be four times longer than
+// the original. Vis must handle this possibility.
+func TestVisLength(t *testing.T) {
+	testString := "All work and no play makes Jack a dull boy\n"
+	for i := 0; i < 20; i++ {
+		Vis(testString)
+		testString = testString + testString
 	}
 }

--- a/walk.go
+++ b/walk.go
@@ -53,9 +53,13 @@ func Walk(root string, exlcudes []ExcludeFunc, keywords []string) (*DirectoryHie
 
 			// Insert a comment of the full path of the directory's name
 			if creator.curDir != nil {
+				dirname, err := creator.curDir.Path()
+				if err != nil {
+					return err
+				}
 				creator.DH.Entries = append(creator.DH.Entries, Entry{
 					Pos:  len(creator.DH.Entries),
-					Raw:  "# " + filepath.Join(creator.curDir.Path(), entryPathName),
+					Raw:  "# " + filepath.Join(dirname, entryPathName),
 					Type: CommentType,
 				})
 			} else {
@@ -113,9 +117,12 @@ func Walk(root string, exlcudes []ExcludeFunc, keywords []string) (*DirectoryHie
 				}
 			}
 		}
-
+		encodedEntryName, err := Vis(entryPathName)
+		if err != nil {
+			return err
+		}
 		e := Entry{
-			Name:   entryPathName,
+			Name:   encodedEntryName,
 			Pos:    len(creator.DH.Entries),
 			Type:   RelativeType,
 			Set:    creator.curSet,


### PR DESCRIPTION
Refactored gomtree with the `vis` and `unvis` C functions. Validation manifest should now be in same format with upstream mtree in terms of how filenames are represented.

Signed-off-by: Stephen Chung <schung@redhat.com>