### PR TITLE
[bug fix] walk: filter \set keyword correctly

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -106,7 +106,7 @@ func Walk(root string, exlcudes []ExcludeFunc, keywords []string) (*DirectoryHie
 						Name:     "/set",
 						Type:     SpecialType,
 						Pos:      len(creator.DH.Entries),
-						Keywords: append(defaultSetKeywords, klist...),
+						Keywords: keywordSelector(append(defaultSetKeywords, klist...), keywords),
 					}
 					creator.curSet = &e
 					creator.DH.Entries = append(creator.DH.Entries, e)


### PR DESCRIPTION
When checking if a new set is needed once `curSet != nil`, the new set created is not filtered against the `keywords` argument in `Walk()`. This caused new sets to contain keywords found in `defaultSetKeywords`, but not in `keywords`, which should be the 'limiting' factor for what actually is evaluated when `Walk`ing.

Signed-off-by: Stephen Chung <schung@redhat.com>