### PR TITLE
*: have gomtree always evaluate tar_time if it is present

### DIFF
--- a/check.go
+++ b/check.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 )
 
 // Result of a Check
@@ -65,7 +66,15 @@ func Check(root string, dh *DirectoryHierarchy, keywords []string) (*Result, err
 			}
 
 			for _, kv := range kvs {
-				keywordFunc, ok := KeywordFuncs[kv.Keyword()]
+				kw := kv.Keyword()
+				// 'tar_time' keyword evaluation wins against 'time' keyword evaluation
+				if kv.Keyword() == "time" && inSlice("tar_time", keywords) {
+					kw = "tar_time"
+					tartime := fmt.Sprintf("%s.%s", (strings.Split(kv.Value(), ".")[0]), "000000000")
+					kv = KeyVal(KeyVal(kw).ChangeValue(tartime))
+				}
+
+				keywordFunc, ok := KeywordFuncs[kw]
 				if !ok {
 					return nil, fmt.Errorf("Unknown keyword %q for file %q", kv.Keyword(), e.Path())
 				}

--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -54,7 +54,11 @@ func main() {
 			currentKeywords = append([]string{"type"}, currentKeywords...)
 		}
 	} else {
-		currentKeywords = mtree.DefaultKeywords[:]
+		if *flTar != "" {
+			currentKeywords = mtree.DefaultTarKeywords[:]
+		} else {
+			currentKeywords = mtree.DefaultKeywords[:]
+		}
 	}
 	// -K <keywords>
 	if *flAddKeywords != "" {

--- a/keywords.go
+++ b/keywords.go
@@ -59,6 +59,11 @@ func (kv KeyVal) Value() string {
 	return strings.SplitN(strings.TrimSpace(string(kv)), "=", 2)[1]
 }
 
+// ChangeValue changes the value of a KeyVal
+func (kv KeyVal) ChangeValue(newval string) string {
+	return fmt.Sprintf("%s=%s", kv.Keyword(), newval)
+}
+
 // keywordSelector takes an array of "keyword=value" and filters out that only the set of words
 func keywordSelector(keyval, words []string) []string {
 	retList := []string{}
@@ -128,6 +133,17 @@ var (
 		"link",
 		"nlink",
 		"time",
+	}
+	// DefaultTarKeywords has keywords that should be used when creating a manifest from
+	// an archive. Currently, evaluating the # of hardlinks has not been implemented yet
+	DefaultTarKeywords = []string{
+		"size",
+		"type",
+		"uid",
+		"gid",
+		"mode",
+		"link",
+		"tar_time",
 	}
 	// SetKeywords is the default set of keywords calculated for a `/set` SpecialType
 	SetKeywords = []string{
@@ -213,11 +229,7 @@ var (
 		}
 	}
 	tartimeKeywordFunc = func(path string, info os.FileInfo, r io.Reader) (string, error) {
-		t := info.ModTime().Unix()
-		if t == 0 {
-			return "tar_time=0.000000000", nil
-		}
-		return fmt.Sprintf("tar_time=%d.000000000", t), nil
+		return fmt.Sprintf("tar_time=%d.000000000", info.ModTime().Unix()), nil
 	}
 	timeKeywordFunc = func(path string, info os.FileInfo, r io.Reader) (string, error) {
 		t := info.ModTime().UnixNano()

--- a/tar_test.go
+++ b/tar_test.go
@@ -3,7 +3,6 @@ package mtree
 import (
 	"archive/tar"
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -115,17 +114,17 @@ func TestTar(t *testing.T) {
 		switch {
 		case len(res.Failures) > 0:
 			for _, f := range res.Failures {
-				fmt.Printf("%s\n", f)
+				t.Errorf("%s\n", f)
 			}
 			errors += "Keyword validation errors\n"
 		case len(res.Missing) > 0:
 			for _, m := range res.Missing {
-				fmt.Printf("Missing file: %s\n", m.Path())
+				t.Errorf("Missing file: %s\n", m.Path())
 			}
 			errors += "Missing files not expected for this test\n"
 		case len(res.Extra) > 0:
 			for _, e := range res.Extra {
-				fmt.Printf("Extra file: %s\n", e.Path())
+				t.Errorf("Extra file: %s\n", e.Path())
 			}
 			errors += "Extra files not expected for this test\n"
 		}

--- a/walk.go
+++ b/walk.go
@@ -80,7 +80,11 @@ func Walk(root string, exlcudes []ExcludeFunc, keywords []string) (*DirectoryHie
 							defer fh.Close()
 							r = fh
 						}
-						if str, err := KeywordFuncs[keyword](path, info, r); err == nil && str != "" {
+						keywordFunc, ok := KeywordFuncs[keyword]
+						if !ok {
+							return fmt.Errorf("Unknown keyword %q for file %q", keyword, path)
+						}
+						if str, err := keywordFunc(path, info, r); err == nil && str != "" {
 							e.Keywords = append(e.Keywords, str)
 						} else if err != nil {
 							return err
@@ -107,7 +111,11 @@ func Walk(root string, exlcudes []ExcludeFunc, keywords []string) (*DirectoryHie
 							defer fh.Close()
 							r = fh
 						}
-						str, err := KeywordFuncs[keyword](path, info, r)
+						keywordFunc, ok := KeywordFuncs[keyword]
+						if !ok {
+							return fmt.Errorf("Unknown keyword %q for file %q", keyword, path)
+						}
+						str, err := keywordFunc(path, info, r)
 						if err != nil {
 							return err
 						}
@@ -158,7 +166,11 @@ func Walk(root string, exlcudes []ExcludeFunc, keywords []string) (*DirectoryHie
 					defer fh.Close()
 					r = fh
 				}
-				str, err := KeywordFuncs[keyword](path, info, r)
+				keywordFunc, ok := KeywordFuncs[keyword]
+				if !ok {
+					return fmt.Errorf("Unknown keyword %q for file %q", keyword, path)
+				}
+				str, err := keywordFunc(path, info, r)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
make sure go-mtree evaluates "tar_time" if an Entry contains both "time" and "tar_time" when validating. This commit contains a test case pertaining to said functionality. There are also minor fix-ups in this commit, for example, checking to see if `KeywordFunc[keyword]` actually returns a function when `walk`ing.

Signed-off-by: Stephen Chung <schung@redhat.com>