### PR TITLE
check: omitempty rather than `null`

### DIFF
--- a/check.go
+++ b/check.go
@@ -11,8 +11,8 @@ import (
 type Result struct {
 	// list of any failures in the Check
 	Failures []Failure `json:"failures"`
-	Missing  []Entry
-	Extra    []Entry
+	Missing  []Entry   `json:"missing,omitempty"`
+	Extra    []Entry   `json:"extra,omitempty"`
 }
 
 // Failure of a particular keyword for a path


### PR DESCRIPTION
When using `-result-format=json` flag, just show populated fields.

Before:
```bash
$ gomtree -result-format=json -p ./bin -f ./bin.mtree
{"failures":[{"path":"gomtree","keyword":"size","expected":"2646101","got":"2930231"}],"Missing":null,"Extra":null}
```

After:
```bash
$ gomtree -result-format=json -p ./bin -f ./bin.mtree
{"failures":[{"path":"gomtree","keyword":"size","expected":"2646101","got":"2930231"}]}
```

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>