### PR TITLE
main: don't dupliate keywords

### DIFF
--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -102,7 +102,11 @@ func main() {
 	}
 	// -K <keywords>
 	if *flAddKeywords != "" {
-		currentKeywords = append(currentKeywords, splitKeywordsArg(*flAddKeywords)...)
+		for _, kw := range splitKeywordsArg(*flAddKeywords) {
+			if !inSlice(kw, currentKeywords) {
+				currentKeywords = append(currentKeywords, kw)
+			}
+		}
 	}
 
 	// -f <file>


### PR DESCRIPTION
When adding keywords with -K, we don't want to duplicate keywords in the keywords slice.

Signed-off-by: Stephen Chung <schung@redhat.com>