### PR TITLE
[bug fix] tar: explicitly close files after populateTree

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -93,9 +93,6 @@ func (ts *tarStream) readHeaders() {
 			ts.pipeReader.CloseWithError(err)
 			return
 		}
-		defer tmpFile.Close()
-		defer os.Remove(tmpFile.Name())
-
 		// Alright, it's either file or directory
 		encodedName, err := Vis(filepath.Base(hdr.Name))
 		if err != nil {
@@ -175,6 +172,8 @@ func (ts *tarStream) readHeaders() {
 			}
 		}
 		populateTree(&root, &e, hdr, ts)
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
 	}
 }
 


### PR DESCRIPTION
When running `gomtree` on a tar archive representing a large filesystem (I mounted a fedora image to `/mnt`), I got:
```
[schung@localhost Desktop] $ sudo `which gomtree` -c -T mount.tar
2016/07/25 20:03:16 open /tmp/ts.payload.682784237: too many open files
[schung@localhost Desktop] $ echo $?
1
```
The temp files in `tar.go` the files were just being `defer`ed on each iteration and not being closed right away after each iteration, which is what we expect. To resolve, just close the files right after `populateTree`.

Now:
```
[schung@localhost Desktop] $ sudo `which gomtree` -c -T mount.tar > mount.mtree
[schung@localhost Desktop] $ echo $?
0
```