### PR TITLE
cmd: gomtree no arguments

### DIFF
--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -223,12 +223,12 @@ func main() {
 					fmt.Printf("%s missing\n", missingpath)
 				}
 			}
-		} else {
-			log.Println("neither validating or creating a manifest. Please provide additional arguments")
-			isErr = true
-			defer os.Exit(1)
-			return
 		}
+	} else {
+		log.Println("neither validating or creating a manifest. Please provide additional arguments")
+		isErr = true
+		defer os.Exit(1)
+		return
 	}
 }
 


### PR DESCRIPTION
#29 accidentally put the functionality for when gomtree has no arguments inside an unreachable block.

Signed-off-by: Stephen Chung <schung@redhat.com>