### PR TITLE
fix xattr ERANGE

### DIFF
--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -23,6 +23,8 @@ var (
 	flListKeywords = flag.Bool("list-keywords", false, "List the keywords available")
 	flResultFormat = flag.String("result-format", "bsd", "output the validation results using the given format (bsd, json, path)")
 	flTar          = flag.String("T", "", "use tar archive to create or validate a directory hierarchy spec")
+
+	flDebug = flag.Bool("debug", false, "output debug info to STDERR")
 )
 
 var formats = map[string]func(*mtree.Result) string{
@@ -56,6 +58,10 @@ var formats = map[string]func(*mtree.Result) string{
 
 func main() {
 	flag.Parse()
+
+	if *flDebug {
+		os.Setenv("DEBUG", "1")
+	}
 
 	// so that defers cleanly exec
 	var isErr bool

--- a/debug.go
+++ b/debug.go
@@ -1,0 +1,18 @@
+package mtree
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// DebugOutput is the where DEBUG output is written
+var DebugOutput = os.Stderr
+
+// Debugf does formatted output to DebugOutput, only if DEBUG environment variable is set
+func Debugf(format string, a ...interface{}) (n int, err error) {
+	if os.Getenv("DEBUG") != "" {
+		return fmt.Fprintf(DebugOutput, "[%d] [DEBUG] %s\n", time.Now().UnixNano(), fmt.Sprintf(format, a...))
+	}
+	return 0, nil
+}

--- a/keywords.go
+++ b/keywords.go
@@ -185,7 +185,8 @@ var (
 		// The pattern for this keyword key is prefixed by "xattr." followed by the extended attribute "namespace.key".
 		// The keyword value is the SHA1 digest of the extended attribute's value.
 		// In this way, the order of the keys does not matter, and the contents of the value is not revealed.
-		"xattr": xattrKeywordFunc,
+		"xattr":  xattrKeywordFunc,
+		"xattrs": xattrKeywordFunc,
 	}
 )
 

--- a/keywords_linux.go
+++ b/keywords_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package mtree
 
 import (

--- a/xattr/xattr.go
+++ b/xattr/xattr.go
@@ -29,7 +29,14 @@ func List(path string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return strings.Split(strings.TrimRight(string(dest[:i]), nilByte), nilByte), nil
+
+	// If the returned list is empty, return nil instead of []string{""}
+	str := string(dest[:i])
+	if str == "" {
+		return nil, nil
+	}
+
+	return strings.Split(strings.TrimRight(str, nilByte), nilByte), nil
 }
 
 const nilByte = "\x00"


### PR DESCRIPTION
* Fixes `xattr` issue, that caused an ERANGE failure if there we _no_ xattrs on a file.
* add an alias of `xattrs`

Also, this introduces a `-debug` flag to the tool. Where there is an `mtree.Debugf()` function to log to stderr