### PR TITLE
Bsd keywords

### DIFF
--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -71,20 +71,24 @@ func main() {
 		}
 	}()
 
-	// -l
+	// -list-keywords
 	if *flListKeywords {
 		fmt.Println("Available keywords:")
 		for k := range mtree.KeywordFuncs {
-			if inSlice(k, mtree.DefaultKeywords) {
-				fmt.Println(" ", k, " (default)")
-			} else {
-				fmt.Println(" ", k)
+			fmt.Print(" ")
+			fmt.Print(k)
+			if mtree.Keyword(k).Default() {
+				fmt.Print(" (default)")
 			}
+			if !mtree.Keyword(k).Bsd() {
+				fmt.Print(" (not upstream)")
+			}
+			fmt.Print("\n")
 		}
 		return
 	}
 
-	// --output
+	// --result-format
 	formatFunc, ok := formats[*flResultFormat]
 	if !ok {
 		log.Printf("invalid output format: %s", *flResultFormat)
@@ -169,6 +173,7 @@ func main() {
 			return
 		}
 	}
+
 	// -c
 	if *flCreate {
 		// create a directory hierarchy

--- a/keywords.go
+++ b/keywords.go
@@ -23,6 +23,20 @@ import (
 // for each new KeywordFunc
 type KeywordFunc func(path string, info os.FileInfo, r io.Reader) (string, error)
 
+// Keyword is the string name of a keyword, with some convenience functions for
+// determining whether it is a default or bsd standard keyword.
+type Keyword string
+
+// Default returns whether this keyword is in the default set of keywords
+func (k Keyword) Default() bool {
+	return inSlice(string(k), DefaultKeywords)
+}
+
+// Bsd returns whether this keyword is in the upstream FreeBSD mtree(8)
+func (k Keyword) Bsd() bool {
+	return inSlice(string(k), BsdKeywords)
+}
+
 // KeyVal is a "keyword=value"
 type KeyVal string
 
@@ -134,6 +148,7 @@ var (
 		"nlink",
 		"time",
 	}
+
 	// DefaultTarKeywords has keywords that should be used when creating a manifest from
 	// an archive. Currently, evaluating the # of hardlinks has not been implemented yet
 	DefaultTarKeywords = []string{
@@ -145,6 +160,41 @@ var (
 		"link",
 		"tar_time",
 	}
+
+	// BsdKeywords is the set of keywords that is only in the upstream FreeBSD mtree
+	BsdKeywords = []string{
+		"cksum",
+		"device",
+		"flags",
+		"ignore",
+		"gid",
+		"gname",
+		"link",
+		"md5",
+		"md5digest",
+		"mode",
+		"nlink",
+		"nochange",
+		"optional",
+		"ripemd160digest",
+		"rmd160",
+		"rmd160digest",
+		"sha1",
+		"sha1digest",
+		"sha256",
+		"sha256digest",
+		"sha384",
+		"sha384digest",
+		"sha512",
+		"sha512digest",
+		"size",
+		"tags",
+		"time",
+		"type",
+		"uid",
+		"uname",
+	}
+
 	// SetKeywords is the default set of keywords calculated for a `/set` SpecialType
 	SetKeywords = []string{
 		"uid",


### PR DESCRIPTION
To support either producing or checking manifests that are compatible
    with upstream FreeBSD mtree(8) keywords, this flag will only operate on
    upstream keywords. Completely ignoring non-upstream keywords, though
    printing out an INFO to stderr for information purposes.
Example:
```bash
INFO: ignoring "xattrs" as it is not an upstream keyword
    
/set type=file nlink=1 mode=0664 uid=1000 gid=100
. size=4096 type=dir mode=0755 nlink=2 time=1469556206.235575511
    
[...]
```
