### PR TITLE
hierarchy: provide option to list the used keywords in a spec

### DIFF
--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -15,17 +15,17 @@ import (
 )
 
 var (
-	flCreate       = flag.Bool("c", false, "create a directory hierarchy spec")
-	flFile         = flag.String("f", "", "directory hierarchy spec to validate")
-	flPath         = flag.String("p", "", "root path that the hierarchy spec is relative to")
-	flAddKeywords  = flag.String("K", "", "Add the specified (delimited by comma or space) keywords to the current set of keywords")
-	flUseKeywords  = flag.String("k", "", "Use the specified (delimited by comma or space) keywords as the current set of keywords")
-	flListKeywords = flag.Bool("list-keywords", false, "List the keywords available")
-	flResultFormat = flag.String("result-format", "bsd", "output the validation results using the given format (bsd, json, path)")
-	flTar          = flag.String("T", "", "use tar archive to create or validate a directory hierarchy spec")
-	flBsdKeywords  = flag.Bool("bsd-keywords", false, "only operate on keywords that are supported by upstream mtree(8)")
-
-	flDebug = flag.Bool("debug", false, "output debug info to STDERR")
+	flCreate           = flag.Bool("c", false, "create a directory hierarchy spec")
+	flFile             = flag.String("f", "", "directory hierarchy spec to validate")
+	flPath             = flag.String("p", "", "root path that the hierarchy spec is relative to")
+	flAddKeywords      = flag.String("K", "", "Add the specified (delimited by comma or space) keywords to the current set of keywords")
+	flUseKeywords      = flag.String("k", "", "Use the specified (delimited by comma or space) keywords as the current set of keywords")
+	flListKeywords     = flag.Bool("list-keywords", false, "List the keywords available")
+	flResultFormat     = flag.String("result-format", "bsd", "output the validation results using the given format (bsd, json, path)")
+	flTar              = flag.String("T", "", "use tar archive to create or validate a directory hierarchy spec")
+	flBsdKeywords      = flag.Bool("bsd-keywords", false, "only operate on keywords that are supported by upstream mtree(8)")
+	flListUsedKeywords = flag.Bool("list-used", false, "list all the keywords found in a validation manifest")
+	flDebug            = flag.Bool("debug", false, "output debug info to STDERR")
 )
 
 var formats = map[string]func(*mtree.Result) string{
@@ -154,6 +154,25 @@ func main() {
 			isErr = true
 			return
 		}
+	}
+
+	// -list-used
+	if *flListUsedKeywords {
+		if *flFile == "" {
+			log.Println("no specification provided. please provide a validation manifest")
+			defer os.Exit(1)
+			isErr = true
+			return
+		}
+		fmt.Printf("Keywords used in [%s]:\n", *flFile)
+		for _, kw := range mtree.CollectUsedKeywords(dh) {
+			fmt.Printf(" %s", kw)
+			if _, ok := mtree.KeywordFuncs[kw]; !ok {
+				fmt.Print(" (unsupported)")
+			}
+			fmt.Printf("\n")
+		}
+		return
 	}
 
 	// -p <path>

--- a/hierarchy.go
+++ b/hierarchy.go
@@ -25,3 +25,27 @@ func (dh DirectoryHierarchy) WriteTo(w io.Writer) (n int64, err error) {
 	}
 	return sum, nil
 }
+
+// CollectUsedKeywords collects and returns all the keywords used in a
+// a DirectoryHierarchy
+func CollectUsedKeywords(dh *DirectoryHierarchy) []string {
+	if dh != nil {
+		usedkeywords := []string{}
+		for _, e := range dh.Entries {
+			switch e.Type {
+			case FullType, RelativeType, SpecialType:
+				if e.Type != SpecialType || e.Name == "/set" {
+					kvs := e.Keywords
+					for _, kv := range kvs {
+						kw := KeyVal(kv).Keyword()
+						if !inSlice(kw, usedkeywords) {
+							usedkeywords = append(usedkeywords, kw)
+						}
+					}
+				}
+			}
+		}
+		return usedkeywords
+	}
+	return nil
+}


### PR DESCRIPTION
When you specify a validation manifest with the `-f` flag, you can now specify a `-list-used` flag that generates a list of keywords used in that manifest, instead of validating the manifest. This increases a user's control in the workflow of validating a directory or archive.

`gomtree -f <validation manifest> -list-used`

Signed-off-by: Stephen Chung <schung@redhat.com>