### PR TITLE
keywords: return non-zero symlink size

### DIFF
--- a/keywords.go
+++ b/keywords.go
@@ -255,6 +255,11 @@ var (
 		return fmt.Sprintf("mode=%#o", permissions), nil
 	}
 	sizeKeywordFunc = func(path string, info os.FileInfo, r io.Reader) (string, error) {
+		if sys, ok := info.Sys().(*tar.Header); ok {
+			if sys.Typeflag == tar.TypeSymlink {
+				return fmt.Sprintf("size=%d", len(sys.Linkname)), nil
+			}
+		}
 		return fmt.Sprintf("size=%d", info.Size()), nil
 	}
 	cksumKeywordFunc = func(path string, info os.FileInfo, r io.Reader) (string, error) {


### PR DESCRIPTION
Previously, the symlink size reported by a archive/tar header
was 0. This is incorrect, as the size of a symlink should be
the size of its contents, which is just the path to where
the symlink points to. Thus, the size of this file would just
be len(Linkname).

Signed-off-by: Stephen Chung <schung@redhat.com>