### PR TITLE
gomtree: `-list-used` can output JSON

### DIFF
--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -164,13 +164,26 @@ func main() {
 			isErr = true
 			return
 		}
-		fmt.Printf("Keywords used in [%s]:\n", *flFile)
-		for _, kw := range mtree.CollectUsedKeywords(dh) {
-			fmt.Printf(" %s", kw)
-			if _, ok := mtree.KeywordFuncs[kw]; !ok {
-				fmt.Print(" (unsupported)")
+		usedKeywords := mtree.CollectUsedKeywords(dh)
+		if *flResultFormat == "json" {
+			// if they're asking for json, give it to them
+			data := map[string][]string{*flFile: usedKeywords}
+			buf, err := json.MarshalIndent(data, "", "  ")
+			if err != nil {
+				defer os.Exit(1)
+				isErr = true
+				return
 			}
-			fmt.Printf("\n")
+			fmt.Println(string(buf))
+		} else {
+			fmt.Printf("Keywords used in [%s]:\n", *flFile)
+			for _, kw := range usedKeywords {
+				fmt.Printf(" %s", kw)
+				if _, ok := mtree.KeywordFuncs[kw]; !ok {
+					fmt.Print(" (unsupported)")
+				}
+				fmt.Printf("\n")
+			}
 		}
 		return
 	}


### PR DESCRIPTION
Piggybacking on `-result-format`:

```bash
$ tar c .git/ | gomtree -c -T - > git.mtree
$ gomtree -result-format=json -list-used -f ./git.mtree
{
  "./git.mtree": [
    "type",
    "mode",
    "uid",
    "gid",
    "tar_time",
    "size"
  ]
}
$ tar c .git/ | gomtree -c -T - -K sha512digest > git.mtree
$ gomtree -result-format=json -list-used -f ./git.mtree
{
  "./git.mtree": [
    "type",
    "mode",
    "uid",
    "gid",
    "tar_time",
    "size",
    "sha512digest"
  ]
}
```

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>