### PR TITLE
tar_test: don't check for extra/missing when validating relative to "."

### DIFF
--- a/tar_test.go
+++ b/tar_test.go
@@ -276,12 +276,6 @@ func TestTreeTraversal(t *testing.T) {
 		for _, f := range res.Failures {
 			t.Errorf(f.String())
 		}
-		for _, e := range res.Extra {
-			t.Errorf("%s extra not expected", e.Name)
-		}
-		for _, m := range res.Missing {
-			t.Errorf("%s missing not expected", m.Name)
-		}
 	}
 
 	// Now test an archive that requires placeholder directories, i.e, there are
@@ -310,12 +304,6 @@ func TestTreeTraversal(t *testing.T) {
 	if res != nil {
 		for _, f := range res.Failures {
 			t.Errorf(f.String())
-		}
-		for _, e := range res.Extra {
-			t.Errorf("%s extra not expected", e.Name)
-		}
-		for _, m := range res.Missing {
-			t.Errorf("%s missing not expected", m.Name)
 		}
 	}
 }


### PR DESCRIPTION
right now, Check() doesn't check for missing/extra files. So, for the
sake of this test, we don't want to do this check for extra/missing files
when we validate the validation manifest produced from a tar against
the "." root directory (which would be /testdata).

Signed-off-by: Stephen Chung <schung@redhat.com>