### PR TITLE
Add versioning

### DIFF
--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -26,6 +26,7 @@ var (
 	flBsdKeywords      = flag.Bool("bsd-keywords", false, "only operate on keywords that are supported by upstream mtree(8)")
 	flListUsedKeywords = flag.Bool("list-used", false, "list all the keywords found in a validation manifest")
 	flDebug            = flag.Bool("debug", false, "output debug info to STDERR")
+	flVersion          = flag.Bool("version", false, "display the version of this tool")
 )
 
 var formats = map[string]func(*mtree.Result) string{
@@ -71,6 +72,11 @@ func main() {
 			os.Exit(1)
 		}
 	}()
+
+	if *flVersion {
+		fmt.Printf("%s :: %s\n", os.Args[0], mtree.Version)
+		return
+	}
 
 	// -list-keywords
 	if *flListKeywords {

--- a/version.go
+++ b/version.go
@@ -6,12 +6,12 @@ const (
 	// VersionMajor is for an API incompatible changes
 	VersionMajor = 0
 	// VersionMinor is for functionality in a backwards-compatible manner
-	VersionMinor = 2
+	VersionMinor = 3
 	// VersionPatch is for backwards-compatible bug fixes
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = ""
+	VersionDev = "-dev"
 )
 
 // Version is the specification version that the package types support.

--- a/version.go
+++ b/version.go
@@ -1,0 +1,18 @@
+package mtree
+
+import "fmt"
+
+const (
+	// VersionMajor is for an API incompatible changes
+	VersionMajor = 0
+	// VersionMinor is for functionality in a backwards-compatible manner
+	VersionMinor = 2
+	// VersionPatch is for backwards-compatible bug fixes
+	VersionPatch = 0
+
+	// VersionDev indicates development branch. Releases will be empty string.
+	VersionDev = ""
+)
+
+// Version is the specification version that the package types support.
+var Version = fmt.Sprintf("%d.%d.%d%s", VersionMajor, VersionMinor, VersionPatch, VersionDev)


### PR DESCRIPTION
In order to have coordinated releases, add an `mtree.Version` variable and a `-version` flag to the cli.