### PR TITLE
keywords: don't fail on presence of "flags"

### DIFF
--- a/keywords.go
+++ b/keywords.go
@@ -165,7 +165,7 @@ var (
 	BsdKeywords = []string{
 		"cksum",
 		"device",
-		"flags",
+		"flags", // this one is really mostly BSD specific ...
 		"ignore",
 		"gid",
 		"gname",
@@ -225,6 +225,8 @@ var (
 		"sha384digest":    hasherKeywordFunc("sha384digest", sha512.New384),    // A synonym for `sha384`
 		"sha512":          hasherKeywordFunc("sha512digest", sha512.New),       // The SHA512 message digest of the file
 		"sha512digest":    hasherKeywordFunc("sha512digest", sha512.New),       // A synonym for `sha512`
+
+		"flags": flagsKeywordFunc, // NOTE: this is a noop, but here to support the presence of the "flags" keyword.
 
 		// This is not an upstreamed keyword, but used to vary from "time", as tar
 		// archives do not store nanosecond precision. So comparing on "time" will

--- a/keywords_bsd.go
+++ b/keywords_bsd.go
@@ -1,0 +1,15 @@
+// +build darwin freebsd netbsd openbsd
+
+package mtree
+
+import (
+	"io"
+	"os"
+)
+
+var (
+	flagsKeywordFunc = func(path string, info os.FileInfo, r io.Reader) (string, error) {
+		// ideally this will pull in from here https://www.freebsd.org/cgi/man.cgi?query=chflags&sektion=2
+		return "", nil
+	}
+)

--- a/keywords_linux.go
+++ b/keywords_linux.go
@@ -14,6 +14,11 @@ import (
 )
 
 var (
+	// this is bsd specific https://www.freebsd.org/cgi/man.cgi?query=chflags&sektion=2
+	flagsKeywordFunc = func(path string, info os.FileInfo, r io.Reader) (string, error) {
+		return "", nil
+	}
+
 	unameKeywordFunc = func(path string, info os.FileInfo, r io.Reader) (string, error) {
 		if hdr, ok := info.Sys().(*tar.Header); ok {
 			return fmt.Sprintf("uname=%s", hdr.Uname), nil


### PR DESCRIPTION
BSD file's support "flags". These have some similarity with xattr, but
for specific features, rather than general purpose key/values.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>