### PR TITLE
cmd/gomtree/main.go: Handle Extra and Missing cases

### DIFF
--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -36,6 +36,10 @@ var formats = map[string]func([]mtree.InodeDelta) string{
 		for _, delta := range d {
 			if delta.Type() == mtree.Modified {
 				fmt.Fprintln(&buffer, delta)
+			} else if delta.Type() == mtree.Missing {
+				fmt.Fprintln(&buffer, delta)
+			} else if delta.Type() == mtree.Extra {
+				fmt.Fprintln(&buffer, delta)
 			}
 		}
 		return buffer.String()
@@ -417,7 +421,6 @@ func main() {
 			if len(res) > 0 {
 				defer os.Exit(1)
 			}
-
 			out := formatFunc(res)
 			if _, err := os.Stdout.Write([]byte(out)); err != nil {
 				log.Println(err)


### PR DESCRIPTION
The BSD format needed a slight tweak to handle mtree.Extra
and mtree.Missing cases.  It currently only handled the 'Modified'
cases and therefore was not showing missing or extra files during
validation.