### PR TITLE
entries: comment with keyword metadata

### DIFF
--- a/tar.go
+++ b/tar.go
@@ -82,8 +82,13 @@ func (ts *tarStream) readHeaders() {
 		Set:      nil,
 		Keywords: []KeyVal{"type=dir"},
 	}
-	metadataEntries := signatureEntries("<user specified tar archive>")
-	for _, e := range metadataEntries {
+	// insert signature and metadata comments first (user, machine, tree, date)
+	for _, e := range signatureEntries("<user specified tar archive>") {
+		e.Pos = len(ts.creator.DH.Entries)
+		ts.creator.DH.Entries = append(ts.creator.DH.Entries, e)
+	}
+	// insert keyword metadata next
+	for _, e := range keywordEntries(ts.keywords) {
 		e.Pos = len(ts.creator.DH.Entries)
 		ts.creator.DH.Entries = append(ts.creator.DH.Entries, e)
 	}


### PR DESCRIPTION
Since not every keyword applies to every type entry, include a comment
with the keywords the manifest was generated with.

Signed-off-by: Aleksa Sarai <asarai@suse.de>
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>