### PR TITLE
cli.test: fail on cli tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,7 @@ vet: .vet
 cli.test: .cli.test
 
 .cli.test: $(BUILD) $(wildcard ./test/cli/*.sh)
-	@ for test in ./test/cli/*.sh ; do \
-	bash $$test $(CWD) ; \
-	done && touch $@
+	@go run ./test/cli.go ./test/cli/*.sh && touch $@
 
 .PHONY: build
 build: $(BUILD)

--- a/test/cli.go
+++ b/test/cli.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	flag.Parse()
+
+	failed := 0
+	for _, arg := range flag.Args() {
+		cmd := exec.Command("bash", arg)
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		if err := cmd.Run(); err != nil {
+			failed++
+		}
+	}
+	if failed > 0 {
+		fmt.Printf("%d FAILED tests\n", failed)
+		os.Exit(1)
+	}
+}

--- a/test/cli/0001.sh
+++ b/test/cli/0001.sh
@@ -2,7 +2,7 @@
 set -e
 
 name=$(basename $0)
-root=$1
+root="$(dirname $(dirname $(dirname $0)))"
 gomtree=$(readlink -f ${root}/gomtree)
 t=$(mktemp -d /tmp/go-mtree.XXXXXX)
 

--- a/test/cli/0002.sh
+++ b/test/cli/0002.sh
@@ -2,7 +2,7 @@
 set -e
 
 name=$(basename $0)
-root=$1
+root="$(dirname $(dirname $(dirname $0)))"
 gomtree=$(readlink -f ${root}/gomtree)
 t=$(mktemp -d /tmp/go-mtree.XXXXXX)
 

--- a/test/cli/0004.sh
+++ b/test/cli/0004.sh
@@ -3,7 +3,7 @@ set -e
 #set -x
 
 name=$(basename $0)
-root=$1
+root="$(dirname $(dirname $(dirname $0)))"
 gomtree=$(readlink -f ${root}/gomtree)
 t=$(mktemp -d /tmp/go-mtree.XXXXXX)
 

--- a/test/cli/0005.sh
+++ b/test/cli/0005.sh
@@ -2,7 +2,7 @@
 set -e
 
 name=$(basename $0)
-root=$1
+root="$(dirname $(dirname $(dirname $0)))"
 gomtree=$(readlink -f ${root}/gomtree)
 t=$(mktemp -d /tmp/go-mtree.XXXXXX)
 

--- a/test/cli/0006.sh
+++ b/test/cli/0006.sh
@@ -2,7 +2,7 @@
 set -e
 
 name=$(basename $0)
-root=$1
+root="$(dirname $(dirname $(dirname $0)))"
 gomtree=$(readlink -f ${root}/gomtree)
 t=$(mktemp -d /tmp/go-mtree.XXXXXX)
 


### PR DESCRIPTION
This cleans up the Makefile target, and drops the dependency to point to
the $root path of the repo.

Fixes https://github.com/vbatts/go-mtree/issues/98

Reported-by: Aleksa Sarai <asarai@suse.de>
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>