### PR TITLE
compare: make the test output more readable

### DIFF
--- a/compare_test.go
+++ b/compare_test.go
@@ -3,6 +3,7 @@ package mtree
 import (
 	"archive/tar"
 	"bytes"
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"os"
@@ -443,7 +444,12 @@ func TestTarCompare(t *testing.T) {
 			}
 
 			actualFailure = true
-			t.Logf("FAILURE: diff[%d] = %#v", i, delta)
+			buf, err := json.MarshalIndent(delta, "", "  ")
+			if err == nil {
+				t.Logf("FAILURE: diff[%d] = %s", i, string(buf))
+			} else {
+				t.Logf("FAILURE: diff[%d] = %#v", i, delta)
+			}
 		}
 
 		if actualFailure {


### PR DESCRIPTION
This is trying to figure out why the tar logic is not working the same on openbsd. Current output looks like
```
=== RUN   TestTarCompare
--- FAIL: TestTarCompare (0.07s)
        compare_test.go:449: FAILURE: diff[0] = {
                  "type": "modified",
                  "path": "tmpfile",
                  "keys": [
                    {
                      "type": "modified",
                      "name": "gid",
                      "old": "0",
                      "new": "1000"
                    }
                  ]
                }
        compare_test.go:449: FAILURE: diff[1] = {
                  "type": "modified",
                  "path": "testdir",
                  "keys": [
                    {
                      "type": "modified",
                      "name": "gid",
                      "old": "0",
                      "new": "1000"
                    }
                  ]
                }
        compare_test.go:449: FAILURE: diff[2] = {
                  "type": "modified",
                  "path": "testdir/anotherfile",
                  "keys": [
                    {
                      "type": "modified",
                      "name": "gid",
                      "old": "0",
                      "new": "1000"
                    }
                  ]
                }
        compare_test.go:456: expected the diff length to be 0, got 3
FAIL
exit status 1
FAIL    github.com/vbatts/go-mtree      0.123s
```