### PR TITLE
compare: always diff "xattr" keys

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -192,7 +192,7 @@ func compareEntry(oldEntry, newEntry Entry) ([]KeyDelta, error) {
 	for _, kv := range oldKeys {
 		key := kv.Keyword()
 		// only add this diff if the new keys has this keyword
-		if key != "tar_time" && key != "time" && HasKeyword(newKeys, key) == emptyKV {
+		if key != "tar_time" && key != "time" && key != "xattr" && HasKeyword(newKeys, key) == emptyKV {
 			continue
 		}
 
@@ -211,7 +211,7 @@ func compareEntry(oldEntry, newEntry Entry) ([]KeyDelta, error) {
 	for _, kv := range newKeys {
 		key := kv.Keyword()
 		// only add this diff if the old keys has this keyword
-		if key != "tar_time" && key != "time" && HasKeyword(oldKeys, key) == emptyKV {
+		if key != "tar_time" && key != "time" && key != "xattr" && HasKeyword(oldKeys, key) == emptyKV {
 			continue
 		}
 


### PR DESCRIPTION
Because of how xattr works (it will not be set on all files, but it's
possible for it to be added to a file without changing any other key)
it's necessary that we _always_ compute a diff when we hit an inode that
has xattr keys set.

Fixes #107 
Signed-off-by: Aleksa Sarai <asarai@suse.de>

@vbatts: I'm not sure how to add a test that requires `xattrs` being set on files. I could try doing it as a `tar_test` but that feels like an even worse idea.