### PR TITLE
keywords: encode xattr.* keywords with Vis

### DIFF
--- a/keywords_linux.go
+++ b/keywords_linux.go
@@ -62,7 +62,11 @@ var (
 			}
 			klist := []KeyVal{}
 			for k, v := range hdr.Xattrs {
-				klist = append(klist, KeyVal(fmt.Sprintf("xattr.%s=%s", k, base64.StdEncoding.EncodeToString([]byte(v)))))
+				encKey, err := Vis(k, DefaultVisFlags)
+				if err != nil {
+					return emptyKV, err
+				}
+				klist = append(klist, KeyVal(fmt.Sprintf("xattr.%s=%s", encKey, base64.StdEncoding.EncodeToString([]byte(v)))))
 			}
 			return KeyVal(strings.Join(KeyValToString(klist), " ")), nil
 		}
@@ -80,7 +84,11 @@ var (
 			if err != nil {
 				return emptyKV, err
 			}
-			klist[i] = KeyVal(fmt.Sprintf("xattr.%s=%s", xlist[i], base64.StdEncoding.EncodeToString(data)))
+			encKey, err := Vis(xlist[i], DefaultVisFlags)
+			if err != nil {
+				return emptyKV, err
+			}
+			klist[i] = KeyVal(fmt.Sprintf("xattr.%s=%s", encKey, base64.StdEncoding.EncodeToString(data)))
 		}
 		return KeyVal(strings.Join(KeyValToString(klist), " ")), nil
 	}

--- a/test/cli.go
+++ b/test/cli.go
@@ -17,10 +17,11 @@ func main() {
 		cmd.Stdout = os.Stdout
 		if err := cmd.Run(); err != nil {
 			failed++
+			fmt.Fprintf(os.Stderr, "FAILED: %s\n", arg)
 		}
 	}
 	if failed > 0 {
-		fmt.Printf("%d FAILED tests\n", failed)
+		fmt.Fprintf(os.Stderr, "%d FAILED tests\n", failed)
 		os.Exit(1)
 	}
 }

--- a/test/cli/0003.sh
+++ b/test/cli/0003.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+name=$(basename $0)
+root="$(dirname $(dirname $(dirname $0)))"
+gomtree=$(readlink -f ${root}/gomtree)
+t=$(mktemp -d /tmp/go-mtree.XXXXXX)
+
+setfattr -n user.has_xattrs -v "" "${t}" || exit 0
+
+echo "[${name}] Running in ${t}"
+
+mkdir "${t}/dir"
+touch "${t}/dir/file"
+
+setfattr -n user.mtree.testing -v "apples and=bananas" "${t}/dir/file"
+$gomtree -c -k "sha256digest,xattrs" -p ${t}/dir > ${t}/${name}.mtree
+
+setfattr -n user.mtree.testing -v "bananas and lemons" "${t}/dir/file"
+! $gomtree -p ${t}/dir -f ${t}/${name}.mtree
+
+setfattr -x user.mtree.testing "${t}/dir/file"
+! $gomtree -p ${t}/dir -f ${t}/${name}.mtree
+
+setfattr -n user.mtree.testing -v "apples and=bananas" "${t}/dir/file"
+setfattr -n user.mtree.another -v "another  a=b" "${t}/dir/file"
+! $gomtree -p ${t}/dir -f ${t}/${name}.mtree
+
+setfattr -n user.mtree.testing -v "apples and=bananas" "${t}/dir/file"
+setfattr -x user.mtree.another "${t}/dir/file"
+$gomtree -p ${t}/dir -f ${t}/${name}.mtree
+
+rm -fr ${t}


### PR DESCRIPTION
This allows for xattr keywords to include spaces and other such options
(which is perfectly valid according to the definition of Lsetxattr --
any character except '\x00' is fair game).

Fixes #109
Signed-off-by: Aleksa Sarai <asarai@suse.de>