### PR TITLE
cli.test: setting xattr requires a value

### DIFF
--- a/test/cli/0003.sh
+++ b/test/cli/0003.sh
@@ -6,7 +6,7 @@ root="$(dirname $(dirname $(dirname $0)))"
 gomtree=$(readlink -f ${root}/gomtree)
 t=$(mktemp -d /tmp/go-mtree.XXXXXX)
 
-setfattr -n user.has_xattrs -v "" "${t}" || exit 0
+setfattr -n user.has.xattrs -v "true" "${t}" || exit 0
 
 echo "[${name}] Running in ${t}"
 


### PR DESCRIPTION
this early check was not valid as it required a value before it would
attempt to set the xattr

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>