### PR TITLE
gomtree: allow manifest to be provided on stdin

### DIFF
--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -257,6 +257,19 @@ func app() error {
 		return nil
 	}
 
+	// no spec manifest has been provided yet, so look for it on stdin
+	if specDh == nil {
+		// load the hierarchy
+		specDh, err = mtree.ParseSpec(os.Stdin)
+		if err != nil {
+			return err
+		}
+
+		// We can't check against more fields than in the specKeywords list, so
+		// currentKeywords can only have a subset of specKeywords.
+		specKeywords = specDh.UsedKeywords()
+	}
+
 	// This is a validation.
 	if specDh != nil && stateDh != nil {
 		var res []mtree.InodeDelta

--- a/test/cli/0008.sh
+++ b/test/cli/0008.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+name=$(basename $0)
+root="$(dirname $(dirname $(dirname $0)))"
+gomtree=$(readlink -f ${root}/gomtree)
+t=$(mktemp -d /tmp/go-mtree.XXXXXX)
+
+echo "[${name}] Running in ${t}"
+
+pushd ${root}
+mkdir -p ${t}/extract
+git archive --format=tar HEAD^{tree} . | tar -C ${t}/extract/ -x
+
+${gomtree} -K sha256digest -c -p ${t}/extract/ > ${t}/${name}.mtree
+
+## This is a use-case for checking a directory, but by reading the manifest from stdin
+## since the `-f` flag is not provided.
+cat ${t}/${name}.mtree | ${gomtree} -p ${t}/extract/
+
+popd
+rm -rf ${t}


### PR DESCRIPTION

like `gomtree -c -p /tmp/dir1 -K sha1 | gomtree -p /tmp/dir2`
