### PR TITLE
unvis_go: leave unicode unchanged with Unvis()

### DIFF
--- a/unvis_go_test.go
+++ b/unvis_go_test.go
@@ -43,3 +43,51 @@ func TestUnvisHelpers(t *testing.T) {
 		}
 	}
 }
+
+func TestUnvisUnicode(t *testing.T) {
+	// Ensure that unicode strings are not messed up by Unvis.
+	for _, test := range []string{
+		"",
+		"this.is.a.normal_string",
+		"AC_Raíz_Certicámara_S.A..pem",
+		"NetLock_Arany_=Class_Gold=_Főtanúsítvány.pem",
+		"TÜBİTAK_UEKAE_Kök_Sertifika_Hizmet_Sağlayıcısı_-_Sürüm_3.pem",
+	} {
+		got, err := Unvis(test)
+		if err != nil {
+			t.Errorf("unexpected error doing unvis(%q): %s", test, err)
+			continue
+		}
+		if got != test {
+			t.Errorf("expected %q to be unchanged, got %q", test, got)
+		}
+	}
+}
+
+func TestVisUnvis(t *testing.T) {
+	// Round-trip testing.
+	for _, test := range []string{
+		"",
+		"this.is.a.normal_string",
+		"AC_Raíz_Certicámara_S.A..pem",
+		"NetLock_Arany_=Class_Gold=_Főtanúsítvány.pem",
+		"TÜBİTAK_UEKAE_Kök_Sertifika_Hizmet_Sağlayıcısı_-_Sürüm_3.pem",
+		"hello world [ this string needs=enco ding! ]",
+		"even \n more encoding necessary\a\a ",
+		"\024 <-- some more weird characters --> 你好，世界",
+	} {
+		enc, err := Vis(test, DefaultVisFlags)
+		if err != nil {
+			t.Errorf("unexpected error doing vis(%q): %s", test, err)
+			continue
+		}
+		dec, err := Unvis(enc)
+		if err != nil {
+			t.Errorf("unexpected error doing unvis(%q): %s", enc, err)
+			continue
+		}
+		if dec != test {
+			t.Errorf("roundtrip failed: unvis(vis(%q) = %q) = %q", test, enc, dec)
+		}
+	}
+}


### PR DESCRIPTION
Because the original code for vis() was ported to Go using the []byte{}
notion, this causes issues for multi-rune bytes (which were not
correctly treated -- and caused loss of information).

Fix this by dealing with []rune instead, which better conveys the
concept at hand. In addition, add tests to ensure that this does not
happen again.

Though, we _really_ should move this code into a library which has a
better test suite -- and the parser itself should be reimplemented to be
less ... 80s.

Fixes: #118
Signed-off-by: Aleksa Sarai <asarai@suse.de>