### PR TITLE
test: Allow using an environment variable to override the test dir

### DIFF
--- a/keywords_linux_test.go
+++ b/keywords_linux_test.go
@@ -13,9 +13,14 @@ import (
 )
 
 func TestXattr(t *testing.T) {
-	// a bit dirty to create/destory a directory in cwd, but often /tmp is
-	// mounted tmpfs and doesn't support xattrs
-	dir, err := ioutil.TempDir(".", "test.xattrs.")
+	testDir, present := os.LookupEnv("MTREE_TESTDIR")
+	if present == false {
+		// a bit dirty to create/destory a directory in cwd,
+		// but often /tmp is mounted tmpfs and doesn't support
+		// xattrs
+		testDir = "."
+	}
+	dir, err := ioutil.TempDir(testDir, "test.xattrs.")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tar_test.go
+++ b/tar_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"syscall"
 	"testing"
 	"time"
@@ -78,11 +79,16 @@ func TestTar(t *testing.T) {
 		t.Fatal("expected a DirectoryHierarchy struct, but got nil")
 	}
 
-	fh, err = os.Create("./testdata/test.mtree")
+	testDir, present := os.LookupEnv("MTREE_TESTDIR")
+	if present == false {
+		testDir = "."
+	}
+	testPath := filepath.Join(testDir, "test.mtree")
+	fh, err = os.Create(testPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove("./testdata/test.mtree")
+	defer os.Remove(testPath)
 
 	// put output of tar walk into test.mtree
 	_, err = tdh.WriteTo(fh)
@@ -92,7 +98,7 @@ func TestTar(t *testing.T) {
 	fh.Close()
 
 	// now simulate gomtree -T testdata/test.tar -f testdata/test.mtree
-	fh, err = os.Open("./testdata/test.mtree")
+	fh, err = os.Open(testPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/xattr/xattr_test.go
+++ b/xattr/xattr_test.go
@@ -10,7 +10,11 @@ import (
 )
 
 func TestXattr(t *testing.T) {
-	fh, err := ioutil.TempFile(".", "xattr.")
+	testDir, present := os.LookupEnv("MTREE_TESTDIR")
+	if present == false {
+		testDir = "."
+	}
+	fh, err := ioutil.TempFile(testDir, "xattr.")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Some build systems may not permit writing to . during build, so allow
that path to be overridden with an environment variable.