### PR TITLE
keyworrd: fix block device value for `type=`

### DIFF
--- a/keywordfunc.go
+++ b/keywordfunc.go
@@ -162,7 +162,7 @@ var (
 			if info.Mode()&os.ModeCharDevice != 0 {
 				return "type=char", nil
 			}
-			return "type=device", nil
+			return "type=block", nil
 		}
 		return emptyKV, nil
 	}

--- a/keywords.go
+++ b/keywords.go
@@ -242,7 +242,6 @@ var (
 	// BsdKeywords is the set of keywords that is only in the upstream FreeBSD mtree
 	BsdKeywords = []Keyword{
 		"cksum",
-		"device",
 		"flags", // this one is really mostly BSD specific ...
 		"ignore",
 		"gid",


### PR DESCRIPTION
Fixes: #127

Reported-by: Lennart Poettering lennart@poettering.net
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>