### PR TITLE
fseval: not nanosecond for mock test

### DIFF
--- a/fseval_test.go
+++ b/fseval_test.go
@@ -1,6 +1,7 @@
 package mtree
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -8,7 +9,7 @@ import (
 	"time"
 )
 
-var mockTime = time.Unix(1337888823, 88288518233)
+var mockTime = time.Unix(1337888823, 0)
 
 // Here be some dodgy testing. In particular, we have to mess around with some
 // of the FsEval functions. In particular, we change all of the FileInfos to a
@@ -155,6 +156,11 @@ func TestCheckFsEval(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(res) > 0 {
-		t.Errorf("%#v", res)
+		buf, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			t.Errorf("%#v", res)
+		} else {
+			t.Errorf("%s", buf)
+		}
 	}
 }


### PR DESCRIPTION
while testing on osx, it seems that it doesn't support nanoseconds so it
fails this check because the mockFsEval returns the nsec precision, but
the actual expected results is:

		        "old": "1337888911.288518233"
			"new": "1337888911.000000000"

Ideally there will be a way to detect when the fs supports nsecs

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>