### PR TITLE
keyval: cleaner struct functions

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -299,7 +299,7 @@ func compareEntry(oldEntry, newEntry Entry) ([]KeyDelta, error) {
 
 		// Modified
 		default:
-			if !KeyValEqual(*diff.Old, *diff.New) {
+			if !diff.Old.Equal(*diff.New) {
 				results = append(results, KeyDelta{
 					diff: Modified,
 					name: name,

--- a/keywords.go
+++ b/keywords.go
@@ -121,18 +121,21 @@ func (kv KeyVal) Value() string {
 	return strings.SplitN(strings.TrimSpace(string(kv)), "=", 2)[1]
 }
 
-// ChangeValue changes the value of a KeyVal
-func (kv KeyVal) ChangeValue(newval string) string {
-	return fmt.Sprintf("%s=%s", kv.Keyword(), newval)
+// NewValue returns a new KeyVal with the newval
+func (kv KeyVal) NewValue(newval string) KeyVal {
+	if suff := kv.KeywordSuffix(); suff != "" {
+		return KeyVal(fmt.Sprintf("%s.%s=%s", kv.Keyword(), suff, newval))
+	}
+	return KeyVal(fmt.Sprintf("%s=%s", kv.Keyword(), newval))
 }
 
-// KeyValEqual returns whether two KeyVal are equivalent. This takes
+// Equal returns whether two KeyVal are equivalent. This takes
 // care of certain odd cases such as tar_mtime, and should be used over
 // using == comparisons directly unless you really know what you're
 // doing.
-func KeyValEqual(a, b KeyVal) bool {
+func (kv KeyVal) Equal(b KeyVal) bool {
 	// TODO: Implement handling of tar_mtime.
-	return a.Keyword() == b.Keyword() && a.Value() == b.Value()
+	return kv.Keyword() == b.Keyword() && kv.KeywordSuffix() == b.KeywordSuffix() && kv.Value() == b.Value()
 }
 
 // keyvalSelector takes an array of KeyVal ("keyword=value") and filters out that only the set of keywords

--- a/keywords_test.go
+++ b/keywords_test.go
@@ -7,6 +7,42 @@ import (
 	"time"
 )
 
+func TestKeyValRoundtrip(t *testing.T) {
+  kv := KeyVal("xattr.security.selinux=dW5jb25maW5lZF91Om9iamVjdF9yOnVzZXJfaG9tZV90OnMwAA==")
+  expected := "xattr"
+  got :=  string(kv.Keyword())
+  if got != expected {
+    t.Errorf("expected %q; got %q", expected, got)
+  }
+
+  expected = "security.selinux"
+  got = kv.KeywordSuffix()
+  if got != expected {
+    t.Errorf("expected %q; got %q", expected, got)
+  }
+
+  expected = "dW5jb25maW5lZF91Om9iamVjdF9yOnVzZXJfaG9tZV90OnMwAA=="
+  got = kv.Value()
+  if got != expected {
+    t.Errorf("expected %q; got %q", expected, got)
+  }
+
+
+  expected = "xattr.security.selinux=farts"
+  got = string(kv.NewValue("farts"))
+  if got != expected {
+    t.Errorf("expected %q; got %q", expected, got)
+  }
+
+  expected = "xattr.security.selinux=farts"
+  kv1 := KeyVal(got)
+  kv2 := kv.NewValue("farts")
+  if !kv2.Equal(kv1) {
+    t.Errorf("expected equality of %q and %q", kv1, kv2)
+  }
+
+}
+
 type fakeFileInfo struct {
 	mtime time.Time
 }


### PR DESCRIPTION
KeyVal specific functions can be a part of the struct.
Also add tests and fix the NewValue functions for suffixes

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>