### PR TITLE
compare: allow nil newDh and oldDh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 go:
   - 1.x
+  - 1.10.x
+  - 1.9.x
   - 1.8.x
-  - 1.7.x
-  - 1.6.3
 
 sudo: false
 


### PR DESCRIPTION
This allows people to create synthetic InodeDeltas, which is something
that umoci would like to be able to do in order to nicely create 'umoci
insert' layers.

Signed-off-by: Aleksa Sarai <asarai@suse.de>