### PR TITLE
walk: directory is expected to be walked. A file is not.

### DIFF
--- a/test/cli/0011.sh
+++ b/test/cli/0011.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+name=$(basename $0)
+root="$(dirname $(dirname $(dirname $0)))"
+gomtree=$(go run ${root}/test/realpath/main.go ${root}/gomtree)
+t=$(mktemp -d /tmp/go-mtree.XXXXXX)
+
+echo "[${name}] Running in ${t}"
+
+## testing comparing two files
+
+pushd ${root}
+mkdir -p ${t}/
+touch ${t}/foo
+
+## can not walk a file. We're expecting a directory.
+## https://github.com/vbatts/go-mtree/issues/166
+! ${gomtree} -c -K uname,uid,gname,gid,type,nlink,link,mode,flags,xattr,xattrs,size,time,sha256 -p ${t}/foo
+
+popd
+rm -rf ${t}

--- a/walk.go
+++ b/walk.go
@@ -33,6 +33,11 @@ func Walk(root string, excludes []ExcludeFunc, keywords []Keyword, fsEval FsEval
 	if fsEval == nil {
 		fsEval = DefaultFsEval{}
 	}
+	if info, err := os.Stat(root); err == nil {
+		if !info.IsDir() {
+			return nil, fmt.Errorf("%s: Not a directory", filepath.Base(root))
+		}
+	}
 	creator := dhCreator{DH: &DirectoryHierarchy{}, fs: fsEval}
 	// insert signature and metadata comments first (user, machine, tree, date)
 	for _, e := range signatureEntries(root) {


### PR DESCRIPTION
Fixes: #166

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>