### PR TITLE
*: begin incorporating the "validate" subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,31 +104,31 @@ To use the command line tool, first [build it](#Building), then the following.
 This will also include the sha512 digest of the files.
 
 ```shell
-gomtree -c -K sha512digest -p . > /tmp/root.mtree
+gomtree validate -c -K sha512digest -p . > /tmp/root.mtree
 ```
 
 With a tar file:
 
 ```shell
-gomtree -c -K sha512digest -T sometarfile.tar > /tmp/tar.mtree
+gomtree validate -c -K sha512digest -T sometarfile.tar > /tmp/tar.mtree
 ```
 
 ### Validate a manifest
 
 ```shell
-gomtree -p . -f /tmp/root.mtree
+gomtree validate -p . -f /tmp/root.mtree
 ```
 
 With a tar file:
 
 ```shell
-gomtree -T sometarfile.tar -f /tmp/root.mtree
+gomtree validate -T sometarfile.tar -f /tmp/root.mtree
 ```
 
 ### See the supported keywords
 
 ```shell
-gomtree -list-keywords
+gomtree validate -list-keywords
 Available keywords:
  uname
  sha1

--- a/cmd/gomtree/cmd/validate.go
+++ b/cmd/gomtree/cmd/validate.go
@@ -15,6 +15,7 @@ import (
 func NewValidateCommand() *cli.Command {
 	return &cli.Command{
 		Name:   "validate",
+		Usage:  "Create and validate a filesystem hierarchy (this is default tool behavior)",
 		Action: validateAction,
 		Flags: []cli.Flag{
 			// Flags common with mtree(8)

--- a/test/cli/0001a.sh
+++ b/test/cli/0001a.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+name=$(basename $0)
+root="$(dirname $(dirname $(dirname $0)))"
+gomtree=$(go run ${root}/test/realpath/main.go ${root}/gomtree)
+t=$(mktemp -d -t go-mtree.XXXXXX)
+
+echo "[${name}] Running in ${t}"
+# This test is for basic running check of manifest, and check against tar and file system
+#
+
+pushd ${root}
+
+git archive --format=tar -o "${t}/${name}.tar" HEAD^{tree}
+
+prev_umask=$(umask)
+umask 0 # this is so the tar command can set the mode's properly
+mkdir -p ${t}/extract
+tar -C ${t}/extract/ -xf "${t}/${name}.tar"
+umask ${prev_umask}
+
+# create manifest from tar
+${gomtree} validate -K sha256digest -c -T "${t}/${name}.tar" > "${t}/${name}.mtree"
+
+# check tar-manifest against the tar
+${gomtree} validate -f ${t}/${name}.mtree -T "${t}/${name}.tar"
+
+# check tar-manifest against the filesystem
+# git archive makes the uid/gid as 0, so don't check them for this test
+${gomtree} validate -k size,sha256digest,mode,type -f "${t}/${name}.mtree" -p ${t}/extract/
+
+# create a manifest from filesystem
+${gomtree} validate -K sha256digest -c -p "${t}/extract/" > "${t}/${name}.mtree"
+
+# check filesystem-manifest against the filesystem
+${gomtree} validate -f "${t}/${name}.mtree" -p "${t}/extract/"
+
+# check filesystem-manifest against the tar
+# git archive makes the uid/gid as 0, so don't check them for this test
+${gomtree} validate -k size,sha256digest,mode,type -f "${t}/${name}.mtree" -T "${t}/${name}.tar"
+
+popd
+rm -rf ${t}


### PR DESCRIPTION
Update the README to show the validate subcommand by default. This doesn't eliminate the default behavior of _not_ using the command, but begins the visibility of using it by default.

Also copy one of the existing tests, to ensure the same behaviour works as we add more subcommands and/or global flags.