### PR TITLE
gomtree: return exit status != 0 on error

### DIFF
--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
@@ -51,23 +50,20 @@ to support xattrs and interacting with tar archives.`
 	app.OnUsageError = func(ctx *cli.Context, err error, isSubcommand bool) error {
 		if ctx.Command.Name == "gomtree" && strings.Contains(err.Error(), "flag provided but not defined") {
 			runValidate = true
-			return nil
 		}
 		return err
 	}
 
-	if err := app.Run(os.Args); err != nil {
-		fmt.Println(err.Error())
-	}
-
-	// So we run the command again with the validate command as the default.
-	if runValidate {
+	err := app.Run(os.Args)
+	// If it failed, run the command again with the validate command as the
+	// default if it failed.
+	if err != nil && runValidate {
 		app.OnUsageError = nil
 		args := []string{os.Args[0], "validate"}
 		args = append(args, os.Args[1:]...)
-		if err := app.Run(args); err != nil {
-			fmt.Println(err.Error())
-		}
+		err = app.Run(args)
 	}
-
+	if err != nil {
+		logrus.Fatal(err)
+	}
 }

--- a/test/cli/0003.sh
+++ b/test/cli/0003.sh
@@ -17,14 +17,14 @@ setfattr -n user.mtree.testing -v "apples and=bananas" "${t}/dir/file"
 $gomtree -c -k "sha256digest,xattrs" -p ${t}/dir > ${t}/${name}.mtree
 
 setfattr -n user.mtree.testing -v "bananas and lemons" "${t}/dir/file"
-! $gomtree -p ${t}/dir -f ${t}/${name}.mtree
+(! $gomtree -p ${t}/dir -f ${t}/${name}.mtree)
 
 setfattr -x user.mtree.testing "${t}/dir/file"
-! $gomtree -p ${t}/dir -f ${t}/${name}.mtree
+(! $gomtree -p ${t}/dir -f ${t}/${name}.mtree)
 
 setfattr -n user.mtree.testing -v "apples and=bananas" "${t}/dir/file"
 setfattr -n user.mtree.another -v "another  a=b" "${t}/dir/file"
-! $gomtree -p ${t}/dir -f ${t}/${name}.mtree
+(! $gomtree -p ${t}/dir -f ${t}/${name}.mtree)
 
 setfattr -n user.mtree.testing -v "apples and=bananas" "${t}/dir/file"
 setfattr -x user.mtree.another "${t}/dir/file"

--- a/test/cli/0009.sh
+++ b/test/cli/0009.sh
@@ -24,7 +24,7 @@ ${gomtree} -k uid,gid,size,type,link,nlink,sha256digest -f ${t}/root.mtree -p ${
 
 # Modify it and make sure that it successfully figures out what changed.
 echo "othe data" > "${t}/root/$(printf 'this file has \u042a some unicode !!')"
-! ${gomtree} -k uid,gid,size,type,link,nlink,sha256digest -f ${t}/root.mtree -p ${t}/root
+(! ${gomtree} -k uid,gid,size,type,link,nlink,sha256digest -f ${t}/root.mtree -p ${t}/root)
 
 echo "some data" > "${t}/root/$(printf 'this file has \u042a some unicode !!')"
 ${gomtree} -k uid,gid,size,type,link,nlink,sha256digest -f ${t}/root.mtree -p ${t}/root

--- a/test/cli/0010.sh
+++ b/test/cli/0010.sh
@@ -19,7 +19,7 @@ rm -rf ${t}/extract/*.go
 ${gomtree} -K sha256digest -c -p ${t}/extract/ > ${t}/${name}-2.mtree
 
 # this _ought_ to fail because the files are missing now
-! ${gomtree} -f ${t}/${name}-1.mtree -f ${t}/${name}-2.mtree
+(! ${gomtree} -f ${t}/${name}-1.mtree -f ${t}/${name}-2.mtree)
 
 popd
 rm -rf ${t}

--- a/test/cli/0011.sh
+++ b/test/cli/0011.sh
@@ -16,7 +16,7 @@ touch ${t}/foo
 
 ## can not walk a file. We're expecting a directory.
 ## https://github.com/vbatts/go-mtree/issues/166
-! ${gomtree} -c -K uname,uid,gname,gid,type,nlink,link,mode,flags,xattr,xattrs,size,time,sha256 -p ${t}/foo
+(! ${gomtree} -c -K uname,uid,gname,gid,type,nlink,link,mode,flags,xattr,xattrs,size,time,sha256 -p ${t}/foo)
 
 popd
 rm -rf ${t}


### PR DESCRIPTION
This was broken during the refactor for "gomtree validate" in commit
83c9fdb78bf7 ("refactor: prefactor for adding new subcommands"),
resulting in any code that relied on our exit code to silently treat all
errors as non-fatal.

Our tests did not catch this due to a quirky POSIX-ism with regards to
`! cmd` and `set -e` which is fixed in a follow-up patch.

Fixes: 83c9fdb78bf7 ("refactor: prefactor for adding new subcommands")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>