### PR TITLE
cmd/mtree2json: implement JSON representation of an mtree spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,10 @@
 BUILD := gomtree
 BUILDPATH := github.com/vbatts/go-mtree/cmd/gomtree
 CWD := $(shell pwd)
-SOURCE_FILES := $(shell find . -type f -name "*.go")
+SOURCE_FILES = $(shell find . -type f -name "*.go")
 CLEAN_FILES := *~
 TAGS :=
 ARCHES := linux,386 linux,amd64 linux,arm linux,arm64 linux,mips64 linux,riscv64 openbsd,amd64 windows,amd64 windows,arm64 darwin,amd64 darwin,arm64
-GO_VER := go1.14
 
 default: build validation
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,59 @@ However, GNU tar truncates a file's modification time to 1-second precision.
 That is, if a file's full modification time is 123456789.123456789, the "tar time" equivalent would be 123456789.000000000.
 This way, if you validate a manifest created using a tar file against an actual root directory, there will be no complaints from `go-mtree` so long as the 1-second precision time of a file in the root directory is the same.
 
+### JSON form
+
+`go-mtree` can also represent a hierarchy specification as JSON via the
+`mtree2json` subcommand (alias `m2j`).
+This is a **go-mtree extension** — it is not part of the BSD mtree(8) format
+and is not interoperable with other `mtree` implementations.
+
+The output is a JSON array.
+Each element represents one file or directory entry and has two fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | string | Full relative path from the spec root (e.g. `"."`, `"subdir"`, `"subdir/file.txt"`) |
+| `keywords` | object | Map of keyword name → value for that entry (inheriting `/set` defaults) |
+
+```json
+[
+  {
+    "path": ".",
+    "keywords": {
+      "gid": "1000",
+      "mode": "0755",
+      "nlink": "6",
+      "size": "4096",
+      "time": "1459370393.273231538",
+      "type": "dir",
+      "uid": "1000"
+    }
+  },
+  {
+    "path": "LICENSE",
+    "keywords": {
+      "gid": "1000",
+      "mode": "0644",
+      "nlink": "1",
+      "sha256digest": "ef4e53d83096be56dc38dbf9bc8ba9e3068bec1ec37c179033d1e8f99a1c2a95",
+      "size": "1502",
+      "time": "1458851690.0",
+      "type": "file",
+      "uid": "1000"
+    }
+  }
+]
+```
+
+Keyword values are always strings, matching the representation used in the
+mtree spec itself (e.g. `"0644"` for mode, `"1459370393.273231538"` for time).
+
+The keyword set can be narrowed with `-k` (use only), `-K` (add), and `-R`
+(remove) — the same flags accepted by `validate`.
+Input can be an existing spec file (`-f`), a directory to walk (`-p`), or
+stdin (default when neither flag is given).
+
 ## Usage
 
 To use the Go programming language library, see [the docs][godoc].

--- a/cmd/gomtree/cmd/reformat.go
+++ b/cmd/gomtree/cmd/reformat.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	cli "github.com/urfave/cli/v2"
+	"github.com/vbatts/go-mtree"
+)
+
+func NewMtree2JsonCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "mtree2json",
+		Usage:   "represent an mtree spec (or walked directory) as JSON",
+		Aliases: []string{"m2j"},
+		Description: `Converts an mtree hierarchy spec to a JSON array of entry objects.
+
+This is a go-mtree extension and is not compatible with BSD mtree(8).
+
+Each entry in the output array has the form:
+
+  {
+    "path":     "<full relative path>",
+    "keywords": { "<keyword>": "<value>", ... }
+  }
+
+Keyword values are strings matching the mtree spec representation.
+/set defaults are resolved per-entry (AllKeys semantics).
+
+Input: -f <spec-file>, -p <dir> to walk, or stdin when neither is given.
+Keyword filtering: -k (use only), -K (add), -R (remove).`,
+		Action: mtree2JsonAction,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "file",
+				Aliases: []string{"f"},
+				Usage:   "mtree spec file to convert (\"-\" for stdin)",
+			},
+			&cli.StringFlag{
+				Name:    "path",
+				Aliases: []string{"p"},
+				Usage:   "root directory to walk and represent as JSON (mutually exclusive with -f)",
+			},
+			&cli.StringFlag{
+				Name:    "use-keywords",
+				Aliases: []string{"k"},
+				Usage:   "comma/space-separated list of keywords to include (default: all from spec)",
+			},
+			&cli.StringFlag{
+				Name:    "add-keywords",
+				Aliases: []string{"K"},
+				Usage:   "comma/space-separated keywords to add to the keyword set",
+			},
+			&cli.StringFlag{
+				Name:    "remove-keywords",
+				Aliases: []string{"R"},
+				Usage:   "comma/space-separated keywords to remove from the keyword set (\"all\" removes all)",
+			},
+		},
+	}
+}
+
+// jsonEntry is the per-file record written to the JSON output.
+type jsonEntry struct {
+	Path     string            `json:"path"`
+	Keywords map[string]string `json:"keywords"`
+}
+
+func mtree2JsonAction(c *cli.Context) error {
+	if c.String("file") != "" && c.String("path") != "" {
+		return fmt.Errorf("-f and -p are mutually exclusive")
+	}
+
+	var (
+		dh  *mtree.DirectoryHierarchy
+		err error
+	)
+
+	switch {
+	case c.String("path") != "":
+		keywords := buildKeywords(c)
+		if len(keywords) == 0 {
+			keywords = mtree.DefaultKeywords[:]
+		}
+		dh, err = mtree.Walk(c.String("path"), nil, keywords, nil)
+		if err != nil {
+			return err
+		}
+
+	default:
+		// -f or stdin
+		var r io.Reader
+		if c.String("file") == "" || c.String("file") == "-" {
+			r = os.Stdin
+		} else {
+			fh, ferr := os.Open(c.String("file"))
+			if ferr != nil {
+				return ferr
+			}
+			defer fh.Close()
+			r = fh
+		}
+		dh, err = mtree.ParseSpec(r)
+		if err != nil {
+			return err
+		}
+	}
+
+	// If no keyword flags were given, default to all keywords in the DH.
+	filterKws := buildKeywords(c)
+	if len(filterKws) == 0 {
+		filterKws = dh.UsedKeywords()
+	}
+
+	var entries []jsonEntry
+	for _, e := range dh.Entries {
+		if e.Type != mtree.RelativeType && e.Type != mtree.FullType {
+			continue
+		}
+		fp, perr := e.Path()
+		if perr != nil {
+			return perr
+		}
+		kwmap := make(map[string]string)
+		for _, kv := range e.AllKeys() {
+			if mtree.InKeywordSlice(kv.Keyword(), filterKws) {
+				kwmap[string(kv.Keyword())] = kv.Value()
+			}
+		}
+		entries = append(entries, jsonEntry{Path: fp, Keywords: kwmap})
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(entries)
+}
+
+// buildKeywords assembles the keyword list from -k/-K/-R flags.
+// Returns nil when no keyword flags were given.
+func buildKeywords(c *cli.Context) []mtree.Keyword {
+	if c.String("use-keywords") == "" && c.String("add-keywords") == "" && c.String("remove-keywords") == "" {
+		return nil
+	}
+	var kws []mtree.Keyword
+	if c.String("use-keywords") != "" {
+		kws = splitKeywordsArg(c.String("use-keywords"))
+	} else {
+		kws = mtree.DefaultKeywords[:]
+	}
+	for _, kw := range splitKeywordsArg(c.String("add-keywords")) {
+		if !mtree.InKeywordSlice(kw, kws) {
+			kws = append(kws, kw)
+		}
+	}
+	if c.String("remove-keywords") != "" {
+		removeKws := splitKeywordsArg(c.String("remove-keywords"))
+		if mtree.InKeywordSlice("all", removeKws) {
+			return []mtree.Keyword{}
+		}
+		filtered := kws[:0:0]
+		for _, kw := range kws {
+			if !mtree.InKeywordSlice(kw, removeKws) {
+				filtered = append(filtered, kw)
+			}
+		}
+		kws = filtered
+	}
+	return kws
+}

--- a/cmd/gomtree/main.go
+++ b/cmd/gomtree/main.go
@@ -42,6 +42,7 @@ to support xattrs and interacting with tar archives.`
 	app.Commands = []*cli.Command{
 		cmd.NewValidateCommand(),
 		cmd.NewMutateCommand(),
+		cmd.NewMtree2JsonCommand(),
 	}
 
 	// Unfortunately urfave/cli is not at good at using DefaultCommand

--- a/test/cli/0017.sh
+++ b/test/cli/0017.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -ex
+
+name=$(basename $0)
+root="$(dirname $(dirname $(dirname $0)))"
+gomtree=$(go run ${root}/test/realpath/main.go ${root}/gomtree)
+t=$(mktemp -d /tmp/go-mtree.XXXXXX)
+
+echo "[${name}] Running in ${t}"
+spec=${root}/testdata/relative.mtree
+
+# mtree2json with -f: spec → JSON
+${gomtree} mtree2json -f ${spec} > ${t}/from_spec.json
+
+# valid JSON (python -m json.tool exits non-zero on invalid JSON)
+python3 -m json.tool ${t}/from_spec.json > /dev/null
+
+# expected paths appear
+grep -q '"path": "lib/foo"' ${t}/from_spec.json
+grep -q '"path": "lib/dir/sub"' ${t}/from_spec.json
+grep -q '"path": "ayo"' ${t}/from_spec.json
+
+# keywords appear as key/value pairs
+grep -q '"type": "file"' ${t}/from_spec.json
+grep -q '"type": "dir"' ${t}/from_spec.json
+
+# -k type: only type keyword in output
+${gomtree} mtree2json -f ${spec} -k type > ${t}/type_only.json
+
+python3 -m json.tool ${t}/type_only.json > /dev/null
+grep -q '"type"' ${t}/type_only.json
+(! grep -q '"size"' ${t}/type_only.json)
+(! grep -q '"mode"' ${t}/type_only.json)
+
+# stdin input
+${gomtree} mtree2json < ${spec} > ${t}/from_stdin.json
+python3 -m json.tool ${t}/from_stdin.json > /dev/null
+grep -q '"path": "lib/foo"' ${t}/from_stdin.json
+
+# -p: walk a directory
+${gomtree} mtree2json -p ${root} > ${t}/from_walk.json
+python3 -m json.tool ${t}/from_walk.json > /dev/null
+grep -q '"path": "."' ${t}/from_walk.json
+
+# -R size: size keyword removed from output
+${gomtree} mtree2json -f ${spec} -R size > ${t}/no_size.json
+
+python3 -m json.tool ${t}/no_size.json > /dev/null
+grep -q '"path": "lib/foo"' ${t}/no_size.json
+(! grep -q '"size"' ${t}/no_size.json)
+
+# -R size,time: multiple keywords removed
+${gomtree} mtree2json -f ${spec} -R size,time > ${t}/no_size_time.json
+
+(! grep -q '"size"' ${t}/no_size_time.json)
+(! grep -q '"time"' ${t}/no_size_time.json)
+grep -q '"mode"' ${t}/no_size_time.json
+
+# -f and -p together should fail
+(! ${gomtree} mtree2json -f ${spec} -p ${root})
+
+# m2j alias works
+${gomtree} m2j -f ${spec} > /dev/null
+
+rm -rf ${t}


### PR DESCRIPTION
Add the mtree2json subcommand (alias: m2j) that converts an mtree spec to a flat JSON array of {path, keywords} objects:

```shell
  gomtree mtree2json -f spec.mtree
  gomtree mtree2json < spec.mtree
  gomtree mtree2json -p /some/dir
```

Input sources:
  -f <file>   parse an existing mtree spec (- for stdin)
  -p <dir>    walk a directory using DefaultKeywords
  (no flags)  read spec from stdin

Keyword filtering (-k/-K/-R) narrows the keywords included per entry; omitting all three defaults to every keyword present in the spec/walk.

Fixes name typo in NewMtree2JsonCommand ("mtree2json," → "mtree2json"), replaces the validateAction stub with a dedicated mtree2JsonAction, and adds CLI test 0017.sh covering spec input, -k/-R filtering, stdin, -p walk, mutually-exclusive flag error, and the m2j alias.