### PR TITLE
mtree: add WalkOptions for a higher-level creation/validation API

### DIFF
--- a/cmd/gomtree/cmd/validate.go
+++ b/cmd/gomtree/cmd/validate.go
@@ -142,59 +142,32 @@ func validateAction(c *cli.Context) error {
 		return fmt.Errorf("invalid output format: %s", c.String("result-format"))
 	}
 
-	var (
-		err             error
-		tmpKeywords     []mtree.Keyword
-		currentKeywords []mtree.Keyword
-	)
+	var err error
 
-	// -k <keywords>
-	if c.String("use-keywords") != "" {
-		tmpKeywords = splitKeywordsArg(c.String("use-keywords"))
-		if !mtree.InKeywordSlice("type", tmpKeywords) {
-			tmpKeywords = append([]mtree.Keyword{"type"}, tmpKeywords...)
-		}
+	// Build keyword set via WalkOptions.
+	// Tar mode starts from DefaultTarKeywords; filesystem mode from DefaultKeywords.
+	var walkOpts *mtree.WalkOptions
+	if c.String("tar") != "" {
+		walkOpts = mtree.NewWalkOptionsFrom(mtree.DefaultTarKeywords)
 	} else {
-		if c.String("tar") != "" {
-			tmpKeywords = mtree.DefaultTarKeywords[:]
-		} else {
-			tmpKeywords = mtree.DefaultKeywords[:]
-		}
+		walkOpts = mtree.NewWalkOptions()
 	}
+	applyKeywordFlags(walkOpts, c)
 
-	// -K <keywords>
-	if c.String("add-keywords") != "" {
-		for _, kw := range splitKeywordsArg(c.String("add-keywords")) {
-			if !mtree.InKeywordSlice(kw, tmpKeywords) {
-				tmpKeywords = append(tmpKeywords, kw)
-			}
-		}
-	}
-
-	// -R <keywords>
-	if c.String("remove-keywords") != "" {
-		removeKws := splitKeywordsArg(c.String("remove-keywords"))
-		if mtree.InKeywordSlice("all", removeKws) {
-			tmpKeywords = []mtree.Keyword{}
-		} else {
-			tmpKeywords = slices.DeleteFunc(tmpKeywords, func(kw mtree.Keyword) bool {
-				return mtree.InKeywordSlice(kw, removeKws)
-			})
-		}
-	}
-
-	// -bsd-keywords
+	// -bsd-keywords: filter to BSD-compatible keywords, warning about each dropped one.
 	if c.Bool("bsd-keywords") {
-		for _, k := range tmpKeywords {
-			if mtree.Keyword(k).Bsd() {
-				currentKeywords = append(currentKeywords, k)
+		var bsdKws []mtree.Keyword
+		for _, k := range walkOpts.Keywords() {
+			if k.Bsd() {
+				bsdKws = append(bsdKws, k)
 			} else {
 				fmt.Fprintf(os.Stderr, "INFO: ignoring %q as it is not an upstream keyword\n", k)
 			}
 		}
-	} else {
-		currentKeywords = tmpKeywords
+		walkOpts.UseKeywords(bsdKws)
 	}
+
+	currentKeywords := walkOpts.Keywords()
 
 	// Check mutual exclusivity of keywords.
 	// TODO(cyphar): Abstract this inside keywords.go.
@@ -262,7 +235,8 @@ func validateAction(c *cli.Context) error {
 	if specKeywords != nil {
 		// If the user hasn't explicitly changed the keyword set, use the spec's.
 		if c.String("use-keywords") == "" && c.String("add-keywords") == "" && c.String("remove-keywords") == "" {
-			currentKeywords = specKeywords
+			walkOpts.UseKeywords(specKeywords)
+			currentKeywords = walkOpts.Keywords()
 		}
 	}
 
@@ -277,10 +251,9 @@ func validateAction(c *cli.Context) error {
 		rootPath = c.String("path")
 	}
 
-	excludes := []mtree.ExcludeFunc{}
 	// -d
 	if c.Bool("directory-only") {
-		excludes = append(excludes, mtree.ExcludeNonDirectories)
+		walkOpts.AddExclude(mtree.ExcludeNonDirectories)
 	}
 
 	// -x
@@ -289,7 +262,7 @@ func validateAction(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		excludes = append(excludes, exFn)
+		walkOpts.AddExclude(exFn)
 	}
 
 	// -X <exclude-file>
@@ -298,7 +271,7 @@ func validateAction(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		excludes = append(excludes, excludeByPatterns(rootPath, patterns))
+		walkOpts.AddExclude(excludeByPatterns(rootPath, patterns))
 	}
 
 	// -C: dump spec with full paths
@@ -349,7 +322,7 @@ func validateAction(c *cli.Context) error {
 			defer fh.Close()
 			input = fh
 		}
-		ts := mtree.NewTarStreamer(input, excludes, currentKeywords)
+		ts := mtree.NewTarStreamer(input, walkOpts.Excludes(), currentKeywords)
 
 		if _, err := io.Copy(io.Discard, ts); err != nil && err != io.EOF {
 			return err
@@ -375,7 +348,7 @@ func validateAction(c *cli.Context) error {
 		}
 	} else {
 		// with a root directory
-		stateDh, err = mtree.Walk(rootPath, excludes, currentKeywords, nil)
+		stateDh, err = walkOpts.Walk(rootPath)
 		if err != nil {
 			return err
 		}
@@ -667,4 +640,17 @@ func splitKeywordsArg(str string) []mtree.Keyword {
 		keywords = append(keywords, mtree.KeywordSynonym(kw))
 	}
 	return keywords
+}
+
+// applyKeywordFlags applies -k/-K/-R flag values from c to o.
+func applyKeywordFlags(o *mtree.WalkOptions, c *cli.Context) {
+	if c.String("use-keywords") != "" {
+		o.UseKeywords(splitKeywordsArg(c.String("use-keywords")))
+	}
+	if c.String("add-keywords") != "" {
+		o.AddKeywords(splitKeywordsArg(c.String("add-keywords"))...)
+	}
+	if c.String("remove-keywords") != "" {
+		o.RemoveKeywords(splitKeywordsArg(c.String("remove-keywords"))...)
+	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,64 @@
+package mtree
+
+import (
+	"log"
+	"os"
+)
+
+func ExampleWalkOptions() {
+	// Create a spec from a directory, adding sha256 and dropping time.
+	dh, err := NewWalkOptions().
+		AddKeywords("sha256digest").
+		RemoveKeywords("time").
+		Walk("/path/to/dir")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if _, err := dh.WriteTo(os.Stdout); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleWalkOptions_Check() {
+	// Validate a directory against a previously created spec.
+	fh, err := os.Open("/path/to/spec.mtree")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer fh.Close()
+
+	spec, err := ParseSpec(fh)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	deltas, err := NewWalkOptions().
+		UseKeywords(spec.UsedKeywords()).
+		Check("/path/to/dir", spec)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, d := range deltas {
+		log.Println(d)
+	}
+}
+
+func ExampleNewTarStreamer() {
+	fh, err := os.Open("rootfs.tar")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer fh.Close()
+
+	excludes := []ExcludeFunc{}
+	ts := NewTarStreamer(fh, excludes, DefaultTarKeywords)
+
+	dh, err := ts.Hierarchy()
+	if err != nil {
+		log.Fatal(err)
+	}
+	_, err =	dh.WriteTo(os.Stdout)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,87 @@
+package mtree
+
+import "slices"
+
+// WalkOptions configures the creation or validation of a DirectoryHierarchy.
+// The zero value is not useful; use NewWalkOptions to obtain a properly
+// initialised instance.
+//
+// Methods return the receiver so calls can be chained:
+//
+//	dh, err := mtree.NewWalkOptions().
+//	    AddKeywords("sha256digest").
+//	    RemoveKeywords("time").
+//	    Walk("/path/to/dir")
+type WalkOptions struct {
+	keywords []Keyword
+	excludes []ExcludeFunc
+	fsEval   FsEval
+}
+
+// NewWalkOptions returns a WalkOptions initialised with DefaultKeywords and no
+// excludes.
+func NewWalkOptions() *WalkOptions {
+	return &WalkOptions{
+		keywords: append([]Keyword{}, DefaultKeywords...),
+	}
+}
+
+// UseKeywords replaces the keyword set entirely with kws.
+// "type" is always prepended if not already present, because the hierarchy
+// traversal depends on it.
+func (o *WalkOptions) UseKeywords(kws []Keyword) *WalkOptions {
+	if !InKeywordSlice("type", kws) {
+		o.keywords = append([]Keyword{"type"}, kws...)
+	} else {
+		o.keywords = append([]Keyword{}, kws...)
+	}
+	return o
+}
+
+// AddKeywords appends kws to the current keyword set, skipping duplicates.
+func (o *WalkOptions) AddKeywords(kws ...Keyword) *WalkOptions {
+	for _, kw := range kws {
+		if !InKeywordSlice(kw, o.keywords) {
+			o.keywords = append(o.keywords, kw)
+		}
+	}
+	return o
+}
+
+// RemoveKeywords removes kws from the current keyword set.
+func (o *WalkOptions) RemoveKeywords(kws ...Keyword) *WalkOptions {
+	o.keywords = slices.DeleteFunc(o.keywords, func(kw Keyword) bool {
+		return InKeywordSlice(kw, kws)
+	})
+	return o
+}
+
+// AddExclude appends an ExcludeFunc to the exclude list.
+func (o *WalkOptions) AddExclude(fn ExcludeFunc) *WalkOptions {
+	o.excludes = append(o.excludes, fn)
+	return o
+}
+
+// SetFsEval sets a custom FsEval implementation. Passing nil restores the
+// default (DefaultFsEval).
+func (o *WalkOptions) SetFsEval(fsEval FsEval) *WalkOptions {
+	o.fsEval = fsEval
+	return o
+}
+
+// Keywords returns a copy of the current keyword set.
+func (o *WalkOptions) Keywords() []Keyword {
+	return o.keywords[:]
+}
+
+// Walk creates a DirectoryHierarchy rooted at root using these options.
+// It is equivalent to calling mtree.Walk(root, excludes, keywords, fsEval).
+func (o *WalkOptions) Walk(root string) (*DirectoryHierarchy, error) {
+	return Walk(root, o.excludes, o.keywords, o.fsEval)
+}
+
+// Check validates root against dh using these options.
+// It is equivalent to calling mtree.Check(root, dh, keywords, fsEval).
+func (o *WalkOptions) Check(root string, dh *DirectoryHierarchy) ([]InodeDelta, error) {
+	return Check(root, dh, o.keywords, o.fsEval)
+}

--- a/options.go
+++ b/options.go
@@ -26,6 +26,15 @@ func NewWalkOptions() *WalkOptions {
 	}
 }
 
+// NewWalkOptionsFrom returns a WalkOptions initialised with the given keyword
+// set. Use this when a keyword set other than DefaultKeywords is needed as the
+// starting point (e.g. DefaultTarKeywords).
+func NewWalkOptionsFrom(kws []Keyword) *WalkOptions {
+	return &WalkOptions{
+		keywords: append([]Keyword{}, kws...),
+	}
+}
+
 // UseKeywords replaces the keyword set entirely with kws.
 // "type" is always prepended if not already present, because the hierarchy
 // traversal depends on it.
@@ -49,7 +58,12 @@ func (o *WalkOptions) AddKeywords(kws ...Keyword) *WalkOptions {
 }
 
 // RemoveKeywords removes kws from the current keyword set.
+// Passing the special value "all" clears the keyword set entirely.
 func (o *WalkOptions) RemoveKeywords(kws ...Keyword) *WalkOptions {
+	if InKeywordSlice("all", kws) {
+		o.keywords = []Keyword{}
+		return o
+	}
 	o.keywords = slices.DeleteFunc(o.keywords, func(kw Keyword) bool {
 		return InKeywordSlice(kw, kws)
 	})
@@ -72,6 +86,11 @@ func (o *WalkOptions) SetFsEval(fsEval FsEval) *WalkOptions {
 // Keywords returns a copy of the current keyword set.
 func (o *WalkOptions) Keywords() []Keyword {
 	return o.keywords[:]
+}
+
+// Excludes returns a copy of the current exclude list.
+func (o *WalkOptions) Excludes() []ExcludeFunc {
+	return o.excludes[:]
 }
 
 // Walk creates a DirectoryHierarchy rooted at root using these options.

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,123 @@
+package mtree
+
+import (
+	"testing"
+)
+
+func TestNewWalkOptions_defaults(t *testing.T) {
+	o := NewWalkOptions()
+	if len(o.Keywords()) == 0 {
+		t.Fatal("expected default keywords to be non-empty")
+	}
+	if !InKeywordSlice("type", o.Keywords()) {
+		t.Error("expected 'type' in default keywords")
+	}
+}
+
+func TestWalkOptions_UseKeywords(t *testing.T) {
+	o := NewWalkOptions().UseKeywords([]Keyword{"size", "mode"})
+	kws := o.Keywords()
+	// type is always prepended
+	if kws[0] != "type" {
+		t.Errorf("expected first keyword to be 'type', got %q", kws[0])
+	}
+	if !InKeywordSlice("size", kws) || !InKeywordSlice("mode", kws) {
+		t.Error("expected 'size' and 'mode' in keywords")
+	}
+}
+
+func TestWalkOptions_UseKeywords_typeAlreadyPresent(t *testing.T) {
+	o := NewWalkOptions().UseKeywords([]Keyword{"type", "size"})
+	count := 0
+	for _, kw := range o.Keywords() {
+		if kw == "type" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one 'type' keyword, got %d", count)
+	}
+}
+
+func TestWalkOptions_AddKeywords(t *testing.T) {
+	o := NewWalkOptions().AddKeywords("sha256digest")
+	if !InKeywordSlice("sha256digest", o.Keywords()) {
+		t.Error("expected 'sha256digest' after AddKeywords")
+	}
+}
+
+func TestWalkOptions_AddKeywords_noDuplicates(t *testing.T) {
+	o := NewWalkOptions().AddKeywords("type", "type")
+	count := 0
+	for _, kw := range o.Keywords() {
+		if kw == "type" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one 'type' after AddKeywords with duplicates, got %d", count)
+	}
+}
+
+func TestWalkOptions_RemoveKeywords(t *testing.T) {
+	o := NewWalkOptions().RemoveKeywords("time", "size")
+	if InKeywordSlice("time", o.Keywords()) {
+		t.Error("expected 'time' to be removed")
+	}
+	if InKeywordSlice("size", o.Keywords()) {
+		t.Error("expected 'size' to be removed")
+	}
+	// other keywords still present
+	if !InKeywordSlice("mode", o.Keywords()) {
+		t.Error("expected 'mode' to remain after removing unrelated keywords")
+	}
+}
+
+func TestWalkOptions_chaining(t *testing.T) {
+	o := NewWalkOptions().
+		UseKeywords([]Keyword{"size", "mode"}).
+		AddKeywords("sha256digest").
+		RemoveKeywords("size")
+
+	kws := o.Keywords()
+	if InKeywordSlice("size", kws) {
+		t.Error("'size' should have been removed")
+	}
+	if !InKeywordSlice("sha256digest", kws) {
+		t.Error("'sha256digest' should be present")
+	}
+	if !InKeywordSlice("mode", kws) {
+		t.Error("'mode' should be present")
+	}
+}
+
+func TestWalkOptions_Walk(t *testing.T) {
+	dh, err := NewWalkOptions().
+		UseKeywords([]Keyword{"type", "mode"}).
+		Walk("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dh.Entries) == 0 {
+		t.Fatal("expected entries from walking testdata/")
+	}
+}
+
+func TestWalkOptions_Check(t *testing.T) {
+	o := NewWalkOptions().UseKeywords([]Keyword{"type", "mode"})
+
+	dh, err := o.Walk("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deltas, err := o.Check("testdata", dh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range deltas {
+		if d.Type() != Same {
+			t.Errorf("unexpected delta: %v", d)
+		}
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -91,6 +91,36 @@ func TestWalkOptions_chaining(t *testing.T) {
 	}
 }
 
+func TestWalkOptions_RemoveKeywords_all(t *testing.T) {
+	o := NewWalkOptions().RemoveKeywords("all")
+	if len(o.Keywords()) != 0 {
+		t.Errorf("expected empty keyword set after RemoveKeywords(all), got %v", o.Keywords())
+	}
+}
+
+func TestNewWalkOptionsFrom(t *testing.T) {
+	o := NewWalkOptionsFrom(DefaultTarKeywords)
+	if !InKeywordSlice("tar_time", o.Keywords()) {
+		t.Error("expected tar_time in keywords from DefaultTarKeywords")
+	}
+	if InKeywordSlice("time", o.Keywords()) {
+		t.Error("expected time NOT in keywords from DefaultTarKeywords")
+	}
+	// Must be independent from the global — mutations must not affect DefaultTarKeywords.
+	before := len(DefaultTarKeywords)
+	o.RemoveKeywords("tar_time")
+	if len(DefaultTarKeywords) != before {
+		t.Error("RemoveKeywords mutated DefaultTarKeywords")
+	}
+}
+
+func TestWalkOptions_Excludes(t *testing.T) {
+	o := NewWalkOptions().AddExclude(ExcludeNonDirectories)
+	if len(o.Excludes()) != 1 {
+		t.Errorf("expected 1 exclude, got %d", len(o.Excludes()))
+	}
+}
+
 func TestWalkOptions_Walk(t *testing.T) {
 	dh, err := NewWalkOptions().
 		UseKeywords([]Keyword{"type", "mode"}).


### PR DESCRIPTION
Introduces `WalkOptions`, an options type that lets callers configure a `DirectoryHierarchy` operation through method chaining rather than managing `[]Keyword`, `[]ExcludeFunc`, and `FsEval` directly:

```golang
  dh, err := mtree.NewWalkOptions().
      AddKeywords("sha256digest").
      RemoveKeywords("time").
      Walk("/path/to/dir")

  deltas, err := mtree.NewWalkOptions().
      UseKeywords(spec.UsedKeywords()).
      Check("/path/to/dir", spec)

API surface:
  NewWalkOptions()               — initialise with DefaultKeywords
  UseKeywords([]Keyword)         — replace keyword set (type always included)
  AddKeywords(...Keyword)        — append without duplicates
  RemoveKeywords(...Keyword)     — remove by name
  AddExclude(ExcludeFunc)        — append an exclude function
  SetFsEval(FsEval)              — set a custom FsEval
  Keywords() []Keyword           — inspect the current set
  Walk(root string)              — create a DirectoryHierarchy
  Check(root string, dh)         — validate a directory against a spec
```

Closes #145